### PR TITLE
add conflict instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is still a prototype and is not yet ready for production, but you are invit
 Metacello new
   baseline: 'Iceberg';
   repository: 'github://npasserini/iceberg:stable';
+  onConflict: [ :ex | ex allow ];
   load.
 ```
 


### PR DESCRIPTION
If we load the latest version of Metacello to get the Cypress management then we get a conflict error while loading. This allow the conflict to be resoleved.
