### PR TITLE
* commented-out ssh-key loading (it wasn't used)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,18 @@ os:
 - osx
 
 smalltalk:
-- Pharo-6.0
-- Pharo-5.0
+- Pharo-alpha
 
 before_install:
 # Installing the dependency until it is included in the VM
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew install libgcrypt --universal; fi
 
-- openssl aes-256-cbc -K $encrypted_3ff905aeb922_key -iv $encrypted_3ff905aeb922_iv
-  -in iceberg_test.key.enc -out iceberg_test.key -d
-- chmod 600 iceberg_test.key
-- mv iceberg_test.key ~/.ssh/id_rsa
+#- openssl aes-256-cbc -K $encrypted_3ff905aeb922_key -iv $encrypted_3ff905aeb922_iv
+#  -in iceberg_test.key.enc -out iceberg_test.key -d
+#- chmod 600 iceberg_test.key
+#- mv iceberg_test.key ~/.ssh/id_rsa
 # Forcing the known host to have the github.com
-- ssh-keyscan github.com >> ~/.ssh/known_hosts
-- ssh-add ~/.ssh/id_rsa
-- cat ~/.ssh/known_hosts
-- ssh -T git@github.com || echo "Ok"
+#- ssh-keyscan github.com >> ~/.ssh/known_hosts
+#- ssh-add ~/.ssh/id_rsa
+#- cat ~/.ssh/known_hosts
+#- ssh -T git@github.com || echo "Ok"


### PR DESCRIPTION
* removed Pharo-5 (which Iceberg doesn't support)
* Changed Pharo-6 to Pharo-alpha, because stable VM doesn't support
iceberg's git

second attempt, based from dev-0.5 branch (although it shouldn't make a difference)
