### PR TITLE
url parsing fix

### DIFF
--- a/Iceberg.package/IceHttpRemote.class/instance/parseUrl.st
+++ b/Iceberg.package/IceHttpRemote.class/instance/parseUrl.st
@@ -1,7 +1,7 @@
 private
 parseUrl
 	| matcher |
-	matcher := '((http|https)\://)(([\w]+)@)*([\w.]+)(\:([\d]+))*(/[\w]+)*/([\w\-]+)/([\w\-]+(.git)?)' asRegex.
+	matcher := '((http|https)\://)(([\w]+)@)*([\w.]+)(\:([\d]+))*(/[\w]+)*/([\w\-]+)/([\w\-.]+(.git)?)' asRegex.
 	(matcher matches: url) 
 		ifTrue: [		
 			user := matcher subexpression: 5.


### PR DESCRIPTION
minor fix to http URL parsing that allows '.' to be part of the last path segment