### PR TITLE
Correct IceNetworkRemote>>userName

### DIFF
--- a/Iceberg.package/IceNetworkRemote.class/instance/userName.st
+++ b/Iceberg.package/IceNetworkRemote.class/instance/userName.st
@@ -1,4 +1,4 @@
 accessing
 userName
-	^user ifNil: [ String empty ] ifNotNil: [ user ].
+	^user ifNil: [ String empty ].
 	

--- a/Iceberg.package/IceNetworkRemote.class/instance/userName.st
+++ b/Iceberg.package/IceNetworkRemote.class/instance/userName.st
@@ -1,3 +1,4 @@
 accessing
 userName
-	^user ifNil: [ String empty ] ifNotNil: ''
+	^user ifNil: [ String empty ] ifNotNil: [ user ].
+	


### PR DESCRIPTION
The method
IceNetworkRemote>>userName
^user ifNil: [ String empty ] ifNotNil: ''.

should be

IceNetworkRemote>>userName
^user ifNil: [ String empty ] ifNotNil: [ user ].