### PR TITLE
Contract the name of a branch to 20 characters for buttons

### DIFF
--- a/Iceberg-UI.package/IceCommitModel.class/instance/contractedNameFor..st
+++ b/Iceberg-UI.package/IceCommitModel.class/instance/contractedNameFor..st
@@ -1,0 +1,5 @@
+utilities
+contractedNameFor: diff
+	"If the name of a branch is too long it is better to contract it in order to limit the UI glitches."
+
+	^ diff repository branch name contractTo: 20

--- a/Iceberg-UI.package/IceCommitModel.class/instance/initialize.st
+++ b/Iceberg-UI.package/IceCommitModel.class/instance/initialize.st
@@ -1,6 +1,6 @@
 initialization
 initialize
 	model := nil asValueHolder.
-	model whenChangedDo: [ :diff | commitButton label: 'Commit onto ', diff repository branch name ].
-	model whenChangedDo: [ :diff | commitPushButton label: 'Commit and Push onto ', diff repository branch name ].
+	model whenChangedDo: [ :diff | commitButton label: 'Commit onto ' , (self contractedNameFor: diff) ].
+	model whenChangedDo: [ :diff | commitPushButton label: 'Commit and Push onto ' , (self contractedNameFor: diff) ].
 	super initialize


### PR DESCRIPTION
I propose to contract the name of the branches if it is too long. 

I choose 20 characters but this is just a proposition. Maybe another length will be better. I'm open to suggestion. (Or maybe others won't even judge the contraction useful) 