### PR TITLE
optimise loading/merge/pull times

### DIFF
--- a/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/commitsInBranch.do..st
+++ b/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/commitsInBranch.do..st
@@ -5,5 +5,4 @@ commitsInBranch: branchName do: aBlock
 		(LGitRevwalk of: repo)
 			pushReference: (repo lookupBranch: branchName);
 			beSortedReverse;
-			do: aBlock.
-	]
+			do: aBlock ]

--- a/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestPlugin.class/instance/remoteActionsFor..st
+++ b/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestPlugin.class/instance/remoteActionsFor..st
@@ -2,5 +2,6 @@ accessing
 remoteActionsFor: aRemote
 	^ { 
 	self newPullRequestRemoteAction.
+	self viewPullRequestsRemoteAction.
 	self removeOldBranchesRemoteAction. 
 	}

--- a/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestPlugin.class/instance/viewPullRequestsRemoteAction.st
+++ b/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestPlugin.class/instance/viewPullRequestsRemoteAction.st
@@ -1,0 +1,8 @@
+private actions
+viewPullRequestsRemoteAction
+	^ GLMGenericAction new
+		action: [ :presentation :model | 
+			self viewPullRequest: model repository remote: presentation selection ];
+		category: 'GitHub';
+		showTitle: 'Review pull requests...'; 
+		yourself

--- a/Iceberg-UI.package/IceEditRepositoryModel.class/instance/initializePresenter.st
+++ b/Iceberg-UI.package/IceEditRepositoryModel.class/instance/initializePresenter.st
@@ -1,5 +1,5 @@
 initialization
 initializePresenter
 	super initializePresenter.
-	self location: self repository location.
+	self location: (self repository location ifNil: [ IceRepository repositoriesLocation ]).
 	self codeDirectory: self repository subdirectory.

--- a/Iceberg-UI.package/IceGlamourPublishBrowser.class/instance/composeBrowserOn..st
+++ b/Iceberg-UI.package/IceGlamourPublishBrowser.class/instance/composeBrowserOn..st
@@ -19,7 +19,7 @@ composeBrowserOn: browser
 				entity: commitInfo; 
 				diff: (commitInfo ifNotNil: [ commitInfo diffWith: repo branch upstream ]);
 				buildOn: a)
-				title: 'Incoming changes' ].
+				title: 'Outgoing changes' ].
 
 	self addDiffTo: browser.
 	self addCommitInfoTo: browser 

--- a/Iceberg-UI.package/IceGlamourUpdateBrowser.class/instance/fetchAction.st
+++ b/Iceberg-UI.package/IceGlamourUpdateBrowser.class/instance/fetchAction.st
@@ -4,7 +4,7 @@ fetchAction
 		action: [ :presentation :repository | 
 			repository fetch.
 			presentation update ];
-		icon: GLMUIThemeExtraIcons glamorousLeftSide;
+		icon: #glamorousLeftSide asIcon;
 		shortcut: $f;
 		title: 'Fetch new versions'; 
 		showTitle

--- a/Iceberg-UI.package/IceGlamourUpdateBrowser.class/instance/loadAction.st
+++ b/Iceberg-UI.package/IceGlamourUpdateBrowser.class/instance/loadAction.st
@@ -1,8 +1,12 @@
 action creators
 loadAction
 	^ GLMGenericAction new
-		action: [ :presentation | presentation selection load. presentation selection: nil ];
-		condition: [ :presentation | presentation selection notNil and: [ presentation selection isMerged ]];
-		icon: (Smalltalk ui icons iconNamed: #changeBlock);
+		action: [ :presentation | 
+			presentation selection load. 
+			presentation selection: nil ];
+		condition: [ :presentation | 
+			presentation selection notNil 
+				and: [ presentation selection isMerged ]];
+		icon: #changeBlock asIcon;
 		shortcut: $l;
 		title: 'Load'; showTitle

--- a/Iceberg-UI.package/IceGlamourUpdateBrowser.class/instance/pullAction.st
+++ b/Iceberg-UI.package/IceGlamourUpdateBrowser.class/instance/pullAction.st
@@ -4,7 +4,7 @@ pullAction
 		action: [ :presentation :repository | 
 			repository pull.
 			presentation update ];
-		icon: GLMUIThemeExtraIcons glamorousLeftSide;
+		icon: #glamorousLeftSide asIcon;
 		shortcut: $p;
 		title: 'Pull'; 
 		showTitle

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/open.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/open.st
@@ -1,4 +1,4 @@
 opening
 open
 	"self open"
-	^ self openOn: IceRepository registry.
+	^ self openOn: Object new

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/addGlobalMenu.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/addGlobalMenu.st
@@ -1,0 +1,10 @@
+building
+addGlobalMenu
+	self
+		act: [ 
+			SettingBrowser new 
+				changePackageSet: { (RPackageOrganizer default packageNamed: 'Iceberg') }; 
+				open; 
+				expandAll ] 
+		icon: #configuration asIcon
+		entitled: 'Global Settings'

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/compose.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/compose.st
@@ -1,0 +1,4 @@
+building
+compose
+	self addGlobalMenu.
+	super compose

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composeBrowserOn..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composeBrowserOn..st
@@ -6,8 +6,8 @@ composeBrowserOn: browser
 
 	browser transmit 
 		to: #repositories; 
-		andShow: [ :presentation :repositories | 
-			self composeRepositories: repositories in: presentation ].
+		andShow: [ :presentation | 
+			self composeRepositoriesIn: presentation ].
 	browser transmit 
 		from: #repositories; 
 		to: #info; 

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composeNotValidIn..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composeNotValidIn..st
@@ -8,5 +8,8 @@ composeNotValidIn: composite
 				"scale to top browser"
 				presentation pane browser pane browser update ] ] entitled: 'Edit...';
 		act: [ :presentation :model | 
+				model restore. 
+				presentation pane browser pane browser update ] entitled: 'Clone';
+		act: [ :presentation :model | 
 			model forgetThen: [ 
 				presentation pane browser pane browser update ] ] entitled: 'Forget'

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composeRepositoriesIn..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composeRepositoriesIn..st
@@ -1,5 +1,5 @@
 building
-composeRepositories: repositories in: composite
+composeRepositoriesIn: composite
 	| table |
 
 	table := composite fastTable.
@@ -12,7 +12,7 @@ composeRepositories: repositories in: composite
 		column: 'Status' evaluated: #status width: 150.
 
 	table updateOn: IceRepositoryRegistryModified from: [ Iceberg announcer weak ].
-	repositories do: [ :repo | 
+	self repositoryRegistry do: [ :repo | 
 		table updateOn: IceRepositoryAnnouncement from: repo announcer ].
 	table updateOn: MCPackageModified from: MCPackageManager announcer.
 	

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/isRepositoryVisible..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/isRepositoryVisible..st
@@ -1,0 +1,4 @@
+private testing
+isRepositoryVisible: aRepository
+	^ aRepository isSystemRepository not 
+		or: [ Iceberg showSystemRepositories ]

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/repositoryRegistry.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/repositoryRegistry.st
@@ -1,0 +1,3 @@
+private accessing
+repositoryRegistry 
+	^ IceRepository registry

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/visibleRepositoryModels.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/visibleRepositoryModels.st
@@ -1,0 +1,5 @@
+private accessing
+visibleRepositoryModels
+	^ self repositoryRegistry 
+		select: [ :each | self isRepositoryVisible: each  ]
+		thenCollect: [ :repo | IceRepositoryModel modelFor: repo ]

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/properties.json
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/properties.json
@@ -6,7 +6,8 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"lastSynchronization"
+		"lastSynchronization",
+		"showSystemRepositories"
 	],
 	"name" : "IceRepositoriesBrowser",
 	"type" : "normal"

--- a/Iceberg.package/IceCommitInfo.class/instance/isAncestorOf..st
+++ b/Iceberg.package/IceCommitInfo.class/instance/isAncestorOf..st
@@ -1,8 +1,4 @@
 comparing
 isAncestorOf: anotherCommit
 	"Warning: this method considers that a commit is ancestor of itself."
-	^ self = anotherCommit or: [ 
-		"I can not be ancestor of a commit older than me so avoid traversing the graph"
-		(self datetime <= anotherCommit datetime) and: [ 
-			anotherCommit parents anySatisfy: [ :parent | 
-				self isAncestorOf: parent  ]]]
+	^ anotherCommit isDescendantOf: self	

--- a/Iceberg.package/IceCommitInfo.class/instance/load.st
+++ b/Iceberg.package/IceCommitInfo.class/instance/load.st
@@ -1,7 +1,5 @@
 actions
 load
-	self repository loadedPackages 
+	(self changedPackagesTo: self repository loadedCode referenceCommit)
 		collect: [ :package | self versionFor: package ]
-		thenDo: [:version | 
-			version load.
-		]
+		thenDo: [:version | version load ]

--- a/Iceberg.package/IceCommitInfo.class/instance/mergeInto..st
+++ b/Iceberg.package/IceCommitInfo.class/instance/mergeInto..st
@@ -1,3 +1,5 @@
 actions
-mergeInto: anIceBranch
-	self backend merge: self id into: anIceBranch basename
+mergeInto: aBranch
+	self repository 
+		merge: self
+		into: aBranch

--- a/Iceberg.package/IceCommitInfo.class/instance/status.st
+++ b/Iceberg.package/IceCommitInfo.class/instance/status.st
@@ -1,7 +1,7 @@
 *Iceberg-UI
 status
-	self isCurrent ifTrue: [ ^ 'Curent' ].
+	self isCurrent ifTrue: [ ^ 'Current' ].
 	self isLoaded ifTrue: [ ^ 'Loaded' ].
-	self isMerged
-		ifTrue: [ ^ 'Not loaded' ]
-		ifFalse: [ ^ 'Not merged' ]
+	self isMerged ifTrue: [ ^ 'Not loaded' ].
+
+	^ 'Not merged'

--- a/Iceberg.package/IceRepository.class/instance/basicMerge..st
+++ b/Iceberg.package/IceRepository.class/instance/basicMerge..st
@@ -3,6 +3,7 @@ basicMerge: aCommitish
 	"Try automatic merge handled by the (git?) repository itself. 
 	Will raise an IceMergeAborted in case that automatic merge 
 	detects conflicts that have to be solved manually."
-	
+	| currentCommit |
+	currentCommit := self loadedCode referenceCommit.
 	self backend merge: aCommitish id.
-	self loadedPackages do: [ :pkg | pkg loadLatest  ].
+	(self headCommit changedPackagesTo: currentCommit) do: #loadLatest

--- a/Iceberg.package/IceRepository.class/instance/basicOrigin.st
+++ b/Iceberg.package/IceRepository.class/instance/basicOrigin.st
@@ -1,5 +1,6 @@
 private
 basicOrigin
+	self isValid ifFalse: [ ^ nil ].
 	^ [ self backend origin ]
 		on: LGit_GIT_ENOTFOUND 
 		do: [ :e | nil ]

--- a/Iceberg.package/IceRepository.class/instance/beSystemRepository.st
+++ b/Iceberg.package/IceRepository.class/instance/beSystemRepository.st
@@ -1,0 +1,3 @@
+accessing
+beSystemRepository
+	system := true

--- a/Iceberg.package/IceRepository.class/instance/branch.st
+++ b/Iceberg.package/IceRepository.class/instance/branch.st
@@ -1,3 +1,4 @@
 accessing
 branch
+	self isValid ifFalse: [ ^ IceUnknownBranch new ].
 	^ self backend branch

--- a/Iceberg.package/IceRepository.class/instance/initialize.st
+++ b/Iceberg.package/IceRepository.class/instance/initialize.st
@@ -1,7 +1,7 @@
 initialization
 initialize
 	super initialize.
+	system := false. "by default, this is not a system repository"
 	commitDictionary := Dictionary new.
 	self initializeAnnouncer.
-
 	loadedCode := IceLoadedCode repository: self.

--- a/Iceberg.package/IceRepository.class/instance/isSystemRepository.st
+++ b/Iceberg.package/IceRepository.class/instance/isSystemRepository.st
@@ -1,0 +1,7 @@
+testing
+isSystemRepository
+	"Indicated if this repository is a system repository (for example, 'pharo' itself).
+	 This is useful because we do not want to treat all repositories the same. System 
+	 repositories, although present, shouldn't be visible by default (unless desired), 
+	 for example"
+	^ system

--- a/Iceberg.package/IceRepository.class/instance/location..st
+++ b/Iceberg.package/IceRepository.class/instance/location..st
@@ -1,4 +1,5 @@
 accessing
 location: aFileReference
 	self backend location: aFileReference.
-	self refresh
+	aFileReference 
+		ifNotNil: [ self refresh ]

--- a/Iceberg.package/IceRepository.class/instance/merge.into..st
+++ b/Iceberg.package/IceRepository.class/instance/merge.into..st
@@ -1,0 +1,7 @@
+actions
+merge: aCommitish into: aBranch
+	"Currently a commitish can only be an IceCommitInfo, but we should be prepared for other 
+	 types of commitish."
+	self backend 
+		merge: aCommitish id 
+		into: aBranch basename

--- a/Iceberg.package/IceRepository.class/instance/mergeConflictsWith..st
+++ b/Iceberg.package/IceRepository.class/instance/mergeConflictsWith..st
@@ -3,10 +3,9 @@ mergeConflictsWith: aCommitish
 	"Use version merger to create a new version. 
 	If all conflicts are resolved, commit it to the repository, 
 	marking it as parent to the received commitish."
-	
 	| versionsChangedInCommit |
-	versionsChangedInCommit := aCommitish versionsChangedSince: (self mergeBaseWith: aCommitish).
 
+	versionsChangedInCommit := aCommitish versionsChangedSince: (self mergeBaseWith: aCommitish).
 	(MCVersionMerger new
 		addVersions: (versionsChangedInCommit collect: #mcVersion);
 		merge)

--- a/Iceberg.package/IceRepository.class/instance/pullFrom..st
+++ b/Iceberg.package/IceRepository.class/instance/pullFrom..st
@@ -1,5 +1,7 @@
 actions
 pullFrom: aRemote
+	| currentCommit |
+	currentCommit := self loadedCode referenceCommit.
 	self backend pullFrom: aRemote.
 	self refresh.
-	self loadedPackages do: #loadLatest.
+	(self headCommit changedPackagesTo: currentCommit) do: #loadLatest

--- a/Iceberg.package/IceRepository.class/instance/remotes.st
+++ b/Iceberg.package/IceRepository.class/instance/remotes.st
@@ -1,3 +1,4 @@
 accessing remotes
 remotes
+	self isValid ifFalse: [ ^ #() ].
 	^ self backend remotes 

--- a/Iceberg.package/IceRepository.class/properties.json
+++ b/Iceberg.package/IceRepository.class/properties.json
@@ -18,7 +18,8 @@
 		"pushRemote",
 		"savedPackages",
 		"commitDictionary",
-		"loadedCode"
+		"loadedCode",
+		"system"
 	],
 	"name" : "IceRepository",
 	"type" : "normal"

--- a/Iceberg.package/IceUnknownBranch.class/README.md
+++ b/Iceberg.package/IceUnknownBranch.class/README.md
@@ -1,0 +1,2 @@
+I'm an unknown branch. 
+I implement an "null pattern" to provide correct output for non-existing local repositories.

--- a/Iceberg.package/IceUnknownBranch.class/instance/description.st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/description.st
@@ -1,0 +1,3 @@
+accessing
+description
+	^ self name

--- a/Iceberg.package/IceUnknownBranch.class/instance/hideYourselfFromCommitWalk..st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/hideYourselfFromCommitWalk..st
@@ -1,0 +1,3 @@
+walk definition
+hideYourselfFromCommitWalk: commitWalk 
+	"Do nothing, I do not have commits."

--- a/Iceberg.package/IceUnknownBranch.class/instance/lastCommit.st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/lastCommit.st
@@ -1,0 +1,3 @@
+accessing
+lastCommit
+	^ self 

--- a/Iceberg.package/IceUnknownBranch.class/instance/name.st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/name.st
@@ -1,0 +1,3 @@
+accessing
+name
+	^ '<Unknown>'

--- a/Iceberg.package/IceUnknownBranch.class/instance/nameForFirstCommit.st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/nameForFirstCommit.st
@@ -1,0 +1,5 @@
+accessing
+nameForFirstCommit
+	"When doing 'first commit' of an unborn branch, we need to declare the branch name, 
+	 we take by default 'master', because this is what most people do."
+	^ 'master'

--- a/Iceberg.package/IceUnknownBranch.class/instance/packageNames.st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/packageNames.st
@@ -1,0 +1,3 @@
+accessing
+packageNames
+	^ #()

--- a/Iceberg.package/IceUnknownBranch.class/instance/versionsFor..st
+++ b/Iceberg.package/IceUnknownBranch.class/instance/versionsFor..st
@@ -1,0 +1,3 @@
+querying
+versionsFor: aPackage 
+	^ #()

--- a/Iceberg.package/IceUnknownBranch.class/properties.json
+++ b/Iceberg.package/IceUnknownBranch.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "EstebanLorenzano 7/19/2017 14:20",
+	"super" : "IceCommitish",
+	"category" : "Iceberg-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "IceUnknownBranch",
+	"type" : "normal"
+}

--- a/Iceberg.package/Iceberg.class/class/settingsOn..st
+++ b/Iceberg.package/Iceberg.class/class/settingsOn..st
@@ -6,6 +6,7 @@ settingsOn: aBuilder
 		with: [ 
 			(aBuilder setting: #enableMetacelloIntegration)
 				target: self;
+				order: 0.1;
 				label: 'Enable Metacello integration';
 				description: 'If selected, Metacello github// repositories will be loaded using iceberg';
 "				icon: (Smalltalk ui icons iconNamed: #smallConfigurationIcon);"
@@ -17,5 +18,10 @@ settingsOn: aBuilder
 							'SCP (git@github.com:<username>/<project>.git)' -> #scpUrl.
 							'HTTPS (https://github.com/<username>/<project>.git)' -> #httpsUrl
 						}.
-				]
+				].
+			(aBuilder setting: #showSystemRepositories) 
+				order: 0.2;
+				label: 'Include system repositories by default';
+				description: 'If checked then system repositories (like ''pharo'') will be shown in repositories list by default';
+				target: self.
 		]

--- a/Iceberg.package/Iceberg.class/class/showSystemRepositories..st
+++ b/Iceberg.package/Iceberg.class/class/showSystemRepositories..st
@@ -1,0 +1,3 @@
+settings
+showSystemRepositories: aBoolean
+	ShowSystemRepositories := aBoolean

--- a/Iceberg.package/Iceberg.class/class/showSystemRepositories.st
+++ b/Iceberg.package/Iceberg.class/class/showSystemRepositories.st
@@ -1,0 +1,3 @@
+settings
+showSystemRepositories
+	^ ShowSystemRepositories ifNil: [ ShowSystemRepositories := false ]

--- a/Iceberg.package/Iceberg.class/properties.json
+++ b/Iceberg.package/Iceberg.class/properties.json
@@ -8,7 +8,8 @@
 	"pools" : [ ],
 	"classvars" : [
 		"EnableMetacelloIntegration",
-		"RemoteTypeSelector"
+		"RemoteTypeSelector",
+		"ShowSystemRepositories"
 	],
 	"instvars" : [ ],
 	"name" : "Iceberg",

--- a/Iceberg.package/TIceRepositoryBackend.trait/instance/isMissing.st
+++ b/Iceberg.package/TIceRepositoryBackend.trait/instance/isMissing.st
@@ -1,3 +1,4 @@
 accessing
 isMissing
-	^ self repositoryDirectory exists not
+	^ self repositoryDirectory isNil 
+		or: [ self repositoryDirectory exists not ]


### PR DESCRIPTION
using same mechanism as for sync, now we take into consideration just changed packages instead scan all packages in repository.
also: 

- fix multi-level submodule directory
- fix #isAnsestorOf: (it was scanning all commits, now uses the correct backend revwalk)
- fix some types
- added "system repositories" concept, to keep pointer to pharo specific repositories (and do not show them by default).
- fix a problem when branches and not valid repositories
