### PR TITLE
cf_packageSorting

### DIFF
--- a/Iceberg-UI.package/IceAbstractModel.class/instance/isModified.st
+++ b/Iceberg-UI.package/IceAbstractModel.class/instance/isModified.st
@@ -1,0 +1,5 @@
+testing
+isModified
+	self isLoaded ifFalse: [ ^ false ].
+	
+	^ self entity isModified

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/sortingSettingsOn..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/sortingSettingsOn..st
@@ -1,0 +1,19 @@
+settings
+sortingSettingsOn: aBuilder
+	<systemsettings>
+	(aBuilder group: #'Packages sorting')
+		parent: #Iceberg;
+		description: 'Options to customize the sorting of the packages in Iceberg.';
+		noOrdering;
+		with: [ (aBuilder pickOne: #toDisplayFirst)
+				order: 1;
+				target: self;
+				label: 'Packages to display first';
+				description: 'The packages that will be shown at the top of the package list.';
+				domainValues: self sortingStrategy class possibleValues.
+			(aBuilder pickOne: #toDisplayLast)
+				order: 2;
+				target: self;
+				label: 'Packages to display last';
+				description: 'The packages that will be shown at the bottom of the package list.';
+				domainValues: self sortingStrategy class possibleValues ]

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/sortingStrategy..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/sortingStrategy..st
@@ -1,0 +1,3 @@
+accessing
+sortingStrategy: anObject
+	SortingStrategy := anObject

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/sortingStrategy.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/sortingStrategy.st
@@ -1,0 +1,3 @@
+accessing
+sortingStrategy
+	^ SortingStrategy ifNil: [ SortingStrategy := IceSortingStrategy new ]

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayFirst..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayFirst..st
@@ -1,0 +1,3 @@
+accessing
+toDisplayFirst: aSymbol
+	^ self sortingStrategy first: aSymbol

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayFirst.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayFirst.st
@@ -1,0 +1,3 @@
+accessing
+toDisplayFirst
+	^ self sortingStrategy first

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayLast..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayLast..st
@@ -1,0 +1,3 @@
+accessing
+toDisplayLast: aSymbol
+	^ self sortingStrategy last: aSymbol

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayLast.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/class/toDisplayLast.st
@@ -1,0 +1,3 @@
+accessing
+toDisplayLast
+	^ self sortingStrategy last

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composePackagesListIn..st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/composePackagesListIn..st
@@ -2,7 +2,7 @@ building
 composePackagesListIn: composite
 	composite fastTable
 		title: 'Packages';
-		display: #savedPackages;
+		display: [ :model | self sortingStrategy sort: model savedPackages ];
 		column: 'Name' evaluated: #nameText width: 200;
 		column: 'Status' evaluated: #status;
 		addAction: self reloadAllPackagesAction;
@@ -14,9 +14,13 @@ composePackagesListIn: composite
 		addSelectionAction: self unloadAndRemovePackageAction;
 		addSelectionAction: self removePackageAction;
 		addSelectionAction: self removePackageFromDiskAction;
+		addAction: self sortModifiedFirstAction;
+		addAction: self sortModifiedLastAction;
+		addAction: self sortModifiedWithOthersAction;
+		addAction: self sortNotLoadedFirstAction;
+		addAction: self sortNotLoadedLastAction;
+		addAction: self sortNotLoadedWithOthersAction;
 		enableFilter: [ :packageModel :pattern | packageModel packageName includesSubstring: pattern caseSensitive: false ];
 		"Plugin actions"
-		dynamicActionsOnSelection: [ :presentation | 
-			presentation selection ifNotNil: [ 
-				presentation entity pluginPackageActionsFor: presentation selection entity ]];
+			dynamicActionsOnSelection: [ :presentation | presentation selection ifNotNil: [ presentation entity pluginPackageActionsFor: presentation selection entity ] ];
 		updateOn: IceCommited from: #announcer

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortModifiedFirstAction.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortModifiedFirstAction.st
@@ -1,0 +1,9 @@
+menu actions - sorting
+sortModifiedFirstAction
+	^ GLMGenericAction new
+		action: [ :presenter | 
+			self sortingStrategy first: #modified.
+			presenter update ];
+		category: 'Sort modified';
+		showTitle: 'First';
+		yourself

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortModifiedLastAction.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortModifiedLastAction.st
@@ -1,0 +1,9 @@
+menu actions - sorting
+sortModifiedLastAction
+	^ GLMGenericAction new
+		action: [ :presenter | 
+			self sortingStrategy last: #modified.
+			presenter update ];
+		category: 'Sort modified';
+		showTitle: 'Last';
+		yourself

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortModifiedWithOthersAction.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortModifiedWithOthersAction.st
@@ -1,0 +1,9 @@
+menu actions - sorting
+sortModifiedWithOthersAction
+	^ GLMGenericAction new
+		action: [ :presenter | 
+			self sortingStrategy withOthers: #modified.
+			presenter update ];
+		category: 'Sort modified';
+		showTitle: 'With other packages';
+		yourself

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortNotLoadedFirstAction.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortNotLoadedFirstAction.st
@@ -1,0 +1,9 @@
+menu actions - sorting
+sortNotLoadedFirstAction
+	^ GLMGenericAction new
+		action: [ :presenter | 
+			self sortingStrategy first: #notLoaded.
+			presenter update ];
+		category: 'Sort not loaded';
+		showTitle: 'First';
+		yourself

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortNotLoadedLastAction.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortNotLoadedLastAction.st
@@ -1,0 +1,9 @@
+menu actions - sorting
+sortNotLoadedLastAction
+	^ GLMGenericAction new
+		action: [ :presenter | 
+			self sortingStrategy last: #notLoaded.
+			presenter update ];
+		category: 'Sort not loaded';
+		showTitle: 'Last';
+		yourself

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortNotLoadedWithOthersAction.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortNotLoadedWithOthersAction.st
@@ -1,0 +1,9 @@
+menu actions - sorting
+sortNotLoadedWithOthersAction
+	^ GLMGenericAction new
+		action: [ :presenter | 
+			self sortingStrategy withOthers: #notLoaded.
+			presenter update ];
+		category: 'Sort not loaded';
+		showTitle: 'With other packages';
+		yourself

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortingStrategy.st
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/instance/sortingStrategy.st
@@ -1,0 +1,3 @@
+accessing
+sortingStrategy
+	^ self class sortingStrategy

--- a/Iceberg-UI.package/IceRepositoriesBrowser.class/properties.json
+++ b/Iceberg-UI.package/IceRepositoriesBrowser.class/properties.json
@@ -4,7 +4,9 @@
 	"category" : "Iceberg-UI-View",
 	"classinstvars" : [ ],
 	"pools" : [ ],
-	"classvars" : [ ],
+	"classvars" : [
+		"SortingStrategy"
+	],
 	"instvars" : [
 		"lastSynchronization",
 		"showSystemRepositories"

--- a/Iceberg-UI.package/IceSortingStrategy.class/README.md
+++ b/Iceberg-UI.package/IceSortingStrategy.class/README.md
@@ -1,0 +1,14 @@
+I am a sorting strategy taking as parameter a collection and returning the collection sorted. The user can customize the sorting to get, for example, the modified entities first or last. 
+
+
+Example
+
+
+	IceSortingStrategy new first: #modified; last: #notLoaded; sort: aCollection
+
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	first:		<aSymbol>		Represent the entities to display first.
+	last:		<aSymbol>		Represent the entities to display last.

--- a/Iceberg-UI.package/IceSortingStrategy.class/class/possibleValues.st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/class/possibleValues.st
@@ -1,0 +1,3 @@
+accessing
+possibleValues
+	^ #(#none #modified #notLoaded)

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/first..st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/first..st
@@ -1,0 +1,6 @@
+accessing
+first: anObject
+	first := anObject.
+	
+	(anObject ~= #none and: [ self last = anObject ])
+		ifTrue: [ self last: #none ]

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/first.st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/first.st
@@ -1,0 +1,3 @@
+accessing
+first
+	^ first

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/initialize.st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/initialize.st
@@ -1,0 +1,5 @@
+initialization
+initialize
+	super initialize.
+	first := #modified.
+	last := #notLoaded

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/last..st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/last..st
@@ -1,0 +1,6 @@
+accessing
+last: anObject
+	last := anObject.
+	
+	(anObject ~= #none and: [ self first = anObject ])
+		ifTrue: [ self first: #none ]

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/last.st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/last.st
@@ -1,0 +1,3 @@
+accessing
+last
+	^ last

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/selectMatching.from..st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/selectMatching.from..st
@@ -1,0 +1,7 @@
+accessing
+selectMatching: aSymbol from: aCollection
+	aSymbol = #modified
+		ifTrue: [ ^ aCollection select: #isModified ].
+	aSymbol = #notLoaded
+		ifTrue: [ ^ aCollection reject: #isLoaded ].
+	self error: 'This sorting is not accepted: ' , aSymbol

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/sort..st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/sort..st
@@ -1,0 +1,12 @@
+sorting
+sort: aListOfPackages
+	| result packages lasts |
+	packages := aListOfPackages.
+	result := OrderedCollection new.
+	self first = #none ifFalse: [ result addAll: (self sortByName: (self selectMatching: self first from: packages)) ].
+	packages := packages copyWithoutAll: result.
+	lasts := self last = #none ifTrue: [ {} ] ifFalse: [ self selectMatching: self last from: packages ].
+	packages := packages copyWithoutAll: lasts.
+	result addAll: (self sortByName: packages).
+	result addAll: (self sortByName: lasts).
+	^ result

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/sortByName..st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/sortByName..st
@@ -1,0 +1,3 @@
+sorting
+sortByName: aCollection
+	^ aCollection sorted: #packageName ascending

--- a/Iceberg-UI.package/IceSortingStrategy.class/instance/withOthers..st
+++ b/Iceberg-UI.package/IceSortingStrategy.class/instance/withOthers..st
@@ -1,0 +1,4 @@
+accessing
+withOthers: aSymbol 
+	self first = aSymbol ifTrue: [ self first: nil ].
+	self last = aSymbol ifTrue: [ self last: nil ]

--- a/Iceberg-UI.package/IceSortingStrategy.class/properties.json
+++ b/Iceberg-UI.package/IceSortingStrategy.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"commentStamp" : "CyrilFerlicot 8/24/2017 23:21",
+	"super" : "Object",
+	"category" : "Iceberg-UI-View",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"first",
+		"last"
+	],
+	"name" : "IceSortingStrategy",
+	"type" : "normal"
+}


### PR DESCRIPTION
Sorting of packages:

- Sort the packages aphabetically
- Add a sorting strategy. The user can customise the sorting to show the modified/not loaded packages first/last. 
- This customisation can be done via the package tab of Iceberg or via settings

For now I set those defaults: 
- First: modified
- Last: not loaded

This is my personnal choice. If it is too personal I can change it :)Issue related: https://github.com/pharo-vcs/iceberg/issues/434