### PR TITLE
450 cherry picking from multiple packages mixes up methods

### DIFF
--- a/Iceberg.package/IceRepository.class/instance/commitCherryPick.withMessage.andParents..st
+++ b/Iceberg.package/IceRepository.class/instance/commitCherryPick.withMessage.andParents..st
@@ -17,7 +17,7 @@ commitCherryPick: pickedCollection withMessage: message andParents: parentCommit
 			workingCopy := (RPackageOrganizer default packageNamed: packageName) mcWorkingCopy.
 			snapshot := (self packageNamed: packageName) loadedVersion snapshot.
 			patcher := MCPatcher snapshot: snapshot.
-			pickedCollection 
+			changes 
 				select: [ :each | each operation notNil ]
 				thenDo: [ :each | each operation applyTo: patcher ].
 			versions add: (MCVersion new


### PR DESCRIPTION
use package specific collection to create patch for cherry pick to prevent method mixups.
Fixes #450