### PR TITLE
20401 Categorization - IceSemanticVersion should follow Object protocol

### DIFF
--- a/Iceberg-Libgit.package/IceSemanticVersion.class/instance/^equals.st
+++ b/Iceberg-Libgit.package/IceSemanticVersion.class/instance/^equals.st
@@ -1,4 +1,4 @@
-testing
+comparing
 = aMagnitude 
 	"Compare the receiver with the argument and answer with true if the 
 	receiver is equal to the argument. Otherwise answer false."

--- a/Iceberg-Libgit.package/IceSemanticVersion.class/instance/^less.st
+++ b/Iceberg-Libgit.package/IceSemanticVersion.class/instance/^less.st
@@ -1,4 +1,4 @@
-testing
+comparing
 < aMagnitude 
 	"Answer whether the receiver is less than the argument."
 	| version |

--- a/Iceberg-Libgit.package/IceSemanticVersion.class/instance/hash.st
+++ b/Iceberg-Libgit.package/IceSemanticVersion.class/instance/hash.st
@@ -1,4 +1,4 @@
-hash
+comparing
 hash
 	^ ((self species hash
 		bitXor: self major)


### PR DESCRIPTION
Put hash, = and < into the same method category as Object
Necessary to get tests green in latest Pharo 7.0 image (ProperMethodCategorizationTest)

Details in https://pharo.fogbugz.com/f/cases/20401