### PR TITLE
Added a noop flush for get ( as per MCRepository>>#flushForScriptGet )

### DIFF
--- a/Iceberg.package/IceMetacelloRepositoryAdapter.class/instance/flushForScriptGet.st
+++ b/Iceberg.package/IceMetacelloRepositoryAdapter.class/instance/flushForScriptGet.st
@@ -1,0 +1,3 @@
+compatibility
+flushForScriptGet
+	"noop"


### PR DESCRIPTION
Added noop flush (same as MCRepository) to allow `get`ting baselines.

An argument could be made that flushing should actually pull the latest version (just like it does in github+filetree), however considering we are typically using the local repo it would be a volatile change. So flushing (pulling) should be (imho) done manually via Iceberg.