### PR TITLE
$/ in a branch name is common. Pass indication of isRemote down

### DIFF
--- a/Iceberg-Libgit.package/IceLibgitCommitWalk.class/instance/fromBranch..st
+++ b/Iceberg-Libgit.package/IceLibgitCommitWalk.class/instance/fromBranch..st
@@ -1,6 +1,6 @@
 walk definition
 fromBranch: branch
-	[ self revwalk pushReference: (lgitRepository lookupBranch: branch name) ]
+	[ self revwalk pushReference: (lgitRepository lookupBranch: branch name remote: branch isRemote) ]
 		on: LGit_GIT_EINVALIDSPEC do: [
 			"branch real branch, so try to find a corresponding treeish using revparse, 
 			this will handle stuff like 'master~1'"

--- a/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/commitsInBranch.do..st
+++ b/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/commitsInBranch.do..st
@@ -1,8 +1,0 @@
-private
-commitsInBranch: branchName do: aBlock
-	"Iterates commit in a branch, in reverse chronological order (latest first)"
-	self withRepoDo: [ :repo |
-		(LGitRevwalk of: repo)
-			pushReference: (repo lookupBranch: branchName);
-			beSortedReverse;
-			do: aBlock ]

--- a/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/lookupHead.st
+++ b/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/lookupHead.st
@@ -5,5 +5,5 @@ lookupHead
 		repo isUnborn ifTrue: [ ^ IceUnbornBranch new ].
 		head := repo head.
 		^ head isBranch 
-			ifTrue: [ IceLocalBranch named: head basename inRepository: self frontend ] 
+			ifTrue: [ IceLocalBranch named: head name inRepository: self frontend ] 
 			ifFalse: [ head object asIcebergObjectInRepository: self ] ]

--- a/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/outgoingCommits.st
+++ b/Iceberg-Libgit.package/IceLibgitLocalRepository.class/instance/outgoingCommits.st
@@ -5,7 +5,7 @@ outgoingCommits
 		| currentBranch commits walk |
 		
 		commits := OrderedCollection new.
-		currentBranch := repo lookupBranch: self branch name.
+		currentBranch := repo lookupBranch: self branch name remote: self branch isRemote.
 	
 		walk := (LGitRevwalk of: repo)
 			pushReference: currentBranch;


### PR DESCRIPTION
I use some semantics in branch names. E.g. fixes/proj-number or 
feature/feature-name.  Or shared projects use user/their-work so make
it work. Pass name instead of baseName to get the full branch (the
refs/heads/ will be removed by other code) and pass the indication of
local/remote down to libgit.