### PR TITLE
Use Matecallo Cypress support if available in the baseline.

### DIFF
--- a/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/projectClass.st
+++ b/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/projectClass.st
@@ -1,0 +1,5 @@
+accessing
+projectClass
+	^ [ self class environment at: #MetacelloCypressBaselineProject ]
+		on: NotFound
+		do: [ super projectClass ]


### PR DESCRIPTION
This support is present in Pharo 6.1 and 7.
It should allow to update Iceberg without removing its packages first.

Close: https://github.com/pharo-vcs/iceberg/issues/546