### PR TITLE
issue/691

### DIFF
--- a/Iceberg.package/IceSystemEventListener.class/class/handlePackagesChange..st
+++ b/Iceberg.package/IceSystemEventListener.class/class/handlePackagesChange..st
@@ -2,7 +2,5 @@ event handling
 handlePackagesChange: packages
 
 	IceRepository registry do: [ :repository | | changed |
-		changed := packages anySatisfy: [ :each | 
-			repository notifyPackageModified: each name ].
-		changed ifTrue: [ 
-			Iceberg announcer announce: (IceRepositoryModified for: repository) ]]
+		changed := packages anySatisfy: [ :each | each isNotNil and: [ repository notifyPackageModified: each name ] ].
+		changed ifTrue: [ 	Iceberg announcer announce: (IceRepositoryModified for: repository) ]]


### PR DESCRIPTION
The affected package in the notification can be nil. 
If the package does not exists the package is nil.
Closes #691 