### PR TITLE
cf_correctAddPackagesFilter

### DIFF
--- a/Iceberg-TipUI.package/IceTipPackageFilter.class/instance/matches..st
+++ b/Iceberg-TipUI.package/IceTipPackageFilter.class/instance/matches..st
@@ -1,4 +1,3 @@
 testing
 matches: aPackageModel
-	^ aPackageModel name asLowercase includesSubstring: self pattern
-	
+	^ aPackageModel name asLowercase includesSubstring: self pattern asLowercase

--- a/Iceberg-UI-Tests.package/IceTipPackageFilterTest.class/instance/testMatches.st
+++ b/Iceberg-UI-Tests.package/IceTipPackageFilterTest.class/instance/testMatches.st
@@ -1,0 +1,13 @@
+tests
+testMatches
+	| filter package |
+	filter := IceTipPackageFilter new.
+	package := self class package.
+	filter pattern: 'Iceberg'.
+	self assert: (filter matches: package).
+	filter pattern: 'ICEBERG'.
+	self assert: (filter matches: package).
+	filter pattern: 'iceberg'.
+	self assert: (filter matches: package).
+	filter pattern: 'noticeberg'.
+	self deny: (filter matches: package)

--- a/Iceberg-UI-Tests.package/IceTipPackageFilterTest.class/properties.json
+++ b/Iceberg-UI-Tests.package/IceTipPackageFilterTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Iceberg-UI-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "IceTipPackageFilterTest",
+	"type" : "normal"
+}


### PR DESCRIPTION
When adding a package, if we filter the list, use #asLowercase on both package name and pattern from the user.Fixes https://github.com/pharo-vcs/iceberg/issues/665