### PR TITLE
Change focus order of commit window

### DIFF
--- a/Iceberg-TipUI.package/IceTipCommentPanel.class/instance/initializeWidgets.st
+++ b/Iceberg-TipUI.package/IceTipCommentPanel.class/instance/initializeWidgets.st
@@ -19,6 +19,6 @@ initializeWidgets
 		yourself).
 		
 	self focusOrder
-		add: pushCheckbox;
 		add: commentText;
-		add: commitButton 
+		add: commitButton;
+		add: pushCheckbox

--- a/Iceberg-TipUI.package/IceTipCommitBrowser.class/instance/initializeWidgets.st
+++ b/Iceberg-TipUI.package/IceTipCommitBrowser.class/instance/initializeWidgets.st
@@ -13,7 +13,7 @@ initializeWidgets
 		self addShortcutsTo: ann widget textArea ].
 			
 	self whenBuiltDo: [ :ann |  self addShortcutsTo: ann widget ].
-	
+
 	self focusOrder 
-		add: diffPanel;
-		add: commentPanel
+		add: commentPanel;
+		add: diffPanel


### PR DESCRIPTION
Instead of selecting the diff view first, select the commit text area.

Fixes: https://github.com/pharo-vcs/iceberg/issues/720

 **/!\ Please read /!\\** 

Since the focus order was already defined I'm not 100% sure it should be like that. But I still think it makes sense to select the commit text area first. I would like the thoughts of the reviewers. 