### PR TITLE
Correct detection of subdirectiory in Pharo 6.1

### DIFF
--- a/Iceberg.package/IceDiff.class/instance/isCodeSubdirectory..st
+++ b/Iceberg.package/IceDiff.class/instance/isCodeSubdirectory..st
@@ -1,4 +1,15 @@
 testing
 isCodeSubdirectory: aNode
+	| nodePathString |
+	self flag: #clean. "
+	This is a hack for Pharo 6.1 because representation of paths changed between Pharo 6.1 and Pharo 7.
+	When Pharo 6.1 will not be maintaned anymose this method can be changed for: 
 	
-	^ aNode path pathString = self repository subdirectory
+	`^ aNode path pathString = self repository subdirectory`.
+	
+	"
+	
+	nodePathString := aNode path pathString.
+	(nodePathString isNotEmpty and: [ nodePathString first = $/ ]) ifTrue: [ nodePathString := nodePathString allButFirst ].
+	
+	^ nodePathString = self repository subdirectory


### PR DESCRIPTION
The representation of Paths changed between Pharo 6.1 and Pharo 7 and the detection of subdirectories is broken in Pharo 6.1 because of that.

Fixes: https://github.com/pharo-vcs/iceberg/issues/735

PLEASE READ THE CHANGES BEFORE INTEGRATING IT!!

I'm not familiar with Paths and maybe there is a better correction to do.

Also maybe it would be cool to test this but I'm not sure how to set up a repository and I don't have the time to do more for now :(