### PR TITLE
Cloning a Git repository should change the path with the project name.

### DIFF
--- a/Iceberg-TipUI.package/IceTipGitRepositoryPanel.class/instance/extractProjectName..st
+++ b/Iceberg-TipUI.package/IceTipGitRepositoryPanel.class/instance/extractProjectName..st
@@ -1,0 +1,7 @@
+utilities
+extractProjectName: aString
+	| matcher |
+	matcher := RxMatcher forString: '.*/(.*)\.git'.
+	^ (matcher matches: aString)
+		ifTrue: [ matcher subexpression: 2 ]
+		ifFalse: [ '' ]

--- a/Iceberg-TipUI.package/IceTipGitRepositoryPanel.class/instance/initializeWidgets.st
+++ b/Iceberg-TipUI.package/IceTipGitRepositoryPanel.class/instance/initializeWidgets.st
@@ -4,6 +4,9 @@ initializeWidgets
 	self initializeRemoteURL.
 	self remoteInputText ghostText: 'e.g., ssh://[user@]host.xz[:port]/path/to/repo.git'.
 	
+	self remoteInputText 	whenTextChanged: [ :text | 
+	self projectLocation appendPath: (self extractProjectName: text) ].
+	
 	self focusOrder 
 		add: self remoteInputText;
 		add: self subdirectoryInputText		


### PR DESCRIPTION
Fixes 743