### PR TITLE
Showing and coping the Commit ID

### DIFF
--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/branchNameMorph.st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/branchNameMorph.st
@@ -1,0 +1,3 @@
+factory
+branchNameMorph
+	^ ('{1} at ' format: {model branchName}) asMorph

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/execute.st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/execute.st
@@ -1,0 +1,4 @@
+execution
+execute
+	Clipboard clipboardText: model commitId.
+	UIManager inform: 'Commitish ID copied to clipboard'.

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/model..st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/model..st
@@ -1,0 +1,3 @@
+accessing
+model: anObject
+	model := anObject

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/model.st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/model.st
@@ -1,0 +1,3 @@
+accessing
+model
+	^ model

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/mouseEnter..st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/mouseEnter..st
@@ -1,0 +1,3 @@
+event handling
+mouseEnter: evt
+	self currentHand showTemporaryCursor: Cursor webLink.

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/mouseLeave..st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/mouseLeave..st
@@ -1,0 +1,3 @@
+event handling
+mouseLeave: evt
+	self currentHand showTemporaryCursor: nil

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/newStatusBarItemOn..st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/newStatusBarItemOn..st
@@ -1,0 +1,12 @@
+factory
+newStatusBarItemOn: aStatusBar
+	self model shortCommitId ifNil: [ ^ self model branchName asMorph ].
+
+	^ PanelMorph new
+		addMorph: self branchNameMorph;
+		addMorph: self shortIdMorph;
+		changeTableLayout;
+		listDirection: #rightToLeft;
+		hResizing: #shrinkWrap;
+		vResizing: #spaceFill;
+		yourself

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/shortIdMorph.st
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/instance/shortIdMorph.st
@@ -1,0 +1,11 @@
+factory
+shortIdMorph
+	^ (LabelMorph contents: model shortCommitId)
+		addEmphasis: TextEmphasis underlined;
+		on: #click send: #execute to: self;
+		on: #mouseEnter send: #mouseEnter: to: self;
+		on: #mouseLeave send: #mouseLeave: to: self;
+		
+		setBalloonText: 'Copy the commit ID to the clipboard';
+		yourself
+	

--- a/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/properties.json
+++ b/Iceberg-TipUI.package/IceTipBranchWithCommitStatusBarItem.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "",
+	"super" : "IceTipStatusBarItem",
+	"category" : "Iceberg-TipUI-Spec-ItemBar",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"model"
+	],
+	"name" : "IceTipBranchWithCommitStatusBarItem",
+	"type" : "normal"
+}

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/browserRepositoryListActivation.st
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/browserRepositoryListActivation.st
@@ -1,0 +1,8 @@
+activation
+browserRepositoryListActivation
+	<classAnnotation>
+	
+	^ CmdContextMenuCommandActivation
+		byItemOf: CmdExtraMenuGroup
+		order: 10000
+		for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/canBeExecutedInContext..st
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/canBeExecutedInContext..st
@@ -1,0 +1,3 @@
+testing
+canBeExecutedInContext: aToolContext
+	^ aToolContext item shortCommitId isNotNil

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/defaultMenuIconName.st
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^ #book

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/defaultMenuItemName.st
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/class/defaultMenuItemName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuItemName
+	^ 'Copy commitish ID'

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/instance/execute.st
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/instance/execute.st
@@ -1,0 +1,4 @@
+execution
+execute
+	Clipboard clipboardText: item commitId.
+	UIManager default inform: 'Commitish ID copied to clipboard'.

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/instance/readParametersFromContext..st
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/instance/readParametersFromContext..st
@@ -1,0 +1,4 @@
+execution
+readParametersFromContext: aToolContext
+	super readParametersFromContext: aToolContext.
+	item := aToolContext item

--- a/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/properties.json
+++ b/Iceberg-TipUI.package/IceTipCopyCommitishCommand.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "",
+	"super" : "IceTipCommand",
+	"category" : "Iceberg-TipUI-Commands",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"item"
+	],
+	"name" : "IceTipCopyCommitishCommand",
+	"type" : "normal"
+}

--- a/Iceberg-TipUI.package/IceTipRepositoriesBrowser.class/instance/initializeRepositoryList.st
+++ b/Iceberg-TipUI.package/IceTipRepositoriesBrowser.class/instance/initializeRepositoryList.st
@@ -9,7 +9,7 @@ initializeRepositoryList
 			yourself);
 		addColumn: (IceTipTableColumn new 
 			id: 'Branch';
-			action: #branchName;
+			action: #branchNameWithCommitId;
 			width: 150;
 			yourself);
 		addColumn: (IceTipTableColumn new 

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branchName.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branchName.st
@@ -4,4 +4,4 @@ branchName
 	 
 	^ [ self entity branch name ]
 		on: IceNotInBranch 
-		do: [ :e | 'Detached at {1}' format: { self entity headCommit shortId } ]
+		do: [ :e | 'Detached' ]

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branchNameWithCommitId.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branchNameWithCommitId.st
@@ -1,0 +1,7 @@
+accessing
+branchNameWithCommitId
+	| branchName |
+	branchName := self branchName.
+	^ branchName = 'Detached' 
+			ifTrue: [ '{1} at {2}' format: { self branchName. self shortCommitId } ]
+			ifFalse: [branchName ]

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/commitId.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/commitId.st
@@ -1,0 +1,3 @@
+accessing
+commitId
+	^ self entity headCommit id

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/shortCommitId.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/shortCommitId.st
@@ -1,0 +1,3 @@
+accessing
+shortCommitId
+	^ [self entity headCommit shortId] on: Error do: [ nil ].

--- a/Iceberg-TipUI.package/IceTipWorkingCopyBrowser.class/instance/initializeStatusBar.st
+++ b/Iceberg-TipUI.package/IceTipWorkingCopyBrowser.class/instance/initializeStatusBar.st
@@ -1,9 +1,8 @@
 initialization
 initializeStatusBar
 	statusBar 
-		addItem: (IceTipStatusBarTargetItem new
-			target: self model;
-			contents: #branchName;
+		addItem: (IceTipBranchWithCommitStatusBarItem new
+			model: self model;
 			yourself);
 		addItem: (IceTipStatusBarTargetItem new 
 			bePositionRight;

--- a/Iceberg-TipUI.package/IceTipWorkingCopyModel.class/instance/branchNameWithCommitId.st
+++ b/Iceberg-TipUI.package/IceTipWorkingCopyModel.class/instance/branchNameWithCommitId.st
@@ -1,3 +1,0 @@
-as yet unclassified
-branchNameWithCommitId
-	^ self branchName

--- a/Iceberg-TipUI.package/IceTipWorkingCopyModel.class/instance/commitId.st
+++ b/Iceberg-TipUI.package/IceTipWorkingCopyModel.class/instance/commitId.st
@@ -1,0 +1,3 @@
+accessing
+commitId
+	^ repositoryModel commitId

--- a/Iceberg-TipUI.package/IceTipWorkingCopyModel.class/instance/shortCommitId.st
+++ b/Iceberg-TipUI.package/IceTipWorkingCopyModel.class/instance/shortCommitId.st
@@ -1,0 +1,3 @@
+accessing
+shortCommitId
+	^ repositoryModel shortCommitId


### PR DESCRIPTION
Adding the short commit ID to the package window.
Adding an option to copy the commit ID.
Adding behavior to copy the commit ID when clicking in it.

Fix #750 