### PR TITLE
Upgrade to Commander 0.6.2

### DIFF
--- a/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/commander..st
+++ b/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/commander..st
@@ -4,5 +4,5 @@ commander: spec
 		baseline: 'Commander' 
 		with: [ 
 			spec 
-				repository: 'github://dionisiydk/Commander:v0.6.1';
+				repository: 'github://pharo-ide/Commander:v0.6.2';
 				loads: #('Core' 'AllActivators' 'Commander-SpecSupport') ]


### PR DESCRIPTION
Now commapder is hosted under pharo-ide and there is new version 0.6.2