### PR TITLE
Add Windows ci with Appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Please be aware this is still an experimental tool, so you have to be careful. B
 
 To better understand Iceberg (or even this documentation), I recommend to read the wiki pages which explain (parts of) the [Iceberg](../../wiki/Iceberg-glossary) and [Git](../../wiki/Some-keys-to-understand-Git-nomenclature) terminology.
 
-[![Appveyor] (https://ci.appveyor.com/api/projects/status/github/pharo-vcs/iceberg)]
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/pharo-vcs/iceberg?svg=true)](https://ci.appveyor.com/project/pharo-vcs/iceberg)  
+
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Please be aware this is still an experimental tool, so you have to be careful. B
 
 To better understand Iceberg (or even this documentation), I recommend to read the wiki pages which explain (parts of) the [Iceberg](../../wiki/Iceberg-glossary) and [Git](../../wiki/Some-keys-to-understand-Git-nomenclature) terminology.
 
+[![Appveyor] (https://ci.appveyor.com/api/projects/status/github/pharo-vcs/iceberg)]
+
 ## FAQ
 
 ***Q.** Image seems freeze when doing a clone of a repository.*  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Please be aware this is still an experimental tool, so you have to be careful. B
 
 To better understand Iceberg (or even this documentation), I recommend to read the wiki pages which explain (parts of) the [Iceberg](../../wiki/Iceberg-glossary) and [Git](../../wiki/Some-keys-to-understand-Git-nomenclature) terminology.
 
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/pharo-vcs/iceberg?svg=true)](https://ci.appveyor.com/project/pharo-vcs/iceberg)  
+[![Travis Build Status](https://travis-ci.org/pharo-vcs/iceberg.svg?branch=master)](https://travis-ci.org/pharo-vcs/iceberg)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/github/pharo-vcs/iceberg?svg=true)](https://ci.appveyor.com/project/pharo-vcs/iceberg)  
 
 
 ## FAQ

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+  CYG_ROOT: C:\cygwin
+  CYG_BASH: C:\cygwin\bin\bash
+  CYG_CACHE: C:\cygwin\var\cache\setup
+  CYG_EXE: C:\cygwin\setup-x86.exe
+  CYG_MIRROR: http://cygwin.mirror.constant.com
+  SCI_RUN: /cygdrive/c/smalltalkCI-master/bin/smalltalkci
+  matrix:
+    - SMALLTALK: Pharo-7.0
+    - SMALLTALK: Pharo-6.1
+
+
+platform:
+  - x86
+
+install:
+  - '%CYG_EXE% -dgnqNO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P unzip'
+  - ps: Start-FileDownload "https://github.com/hpi-swa/smalltalkCI/archive/master.zip" "C:\smalltalkCI.zip"
+  - 7z x C:\smalltalkCI.zip -oC:\ -y > NULL
+
+build: false
+
+test_script:
+  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; exec 0</dev/null; $SCI_RUN"' 


### PR DESCRIPTION
I do not know why the Pharo7.0 job is failing but the 6.1 succeeded to complete:
https://ci.appveyor.com/project/VincentBlondeau/iceberg

I think you still have to activate the pharo-vcs project on appveyor