### PR TITLE
Correct some lints in tests.

### DIFF
--- a/Iceberg-Tests.package/IceBasicRepositoryFixture.class/instance/ensureRemoteRepository.st
+++ b/Iceberg-Tests.package/IceBasicRepositoryFixture.class/instance/ensureRemoteRepository.st
@@ -1,4 +1,0 @@
-initialization
-ensureRemoteRepository
-	
-	^ remoteRepository := factory ensureRemoteRepository

--- a/Iceberg-Tests.package/IceBasicRepositoryFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceBasicRepositoryFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.

--- a/Iceberg-Tests.package/IceBasicRepositoryFixture.class/instance/tearDown.st
+++ b/Iceberg-Tests.package/IceBasicRepositoryFixture.class/instance/tearDown.st
@@ -1,4 +1,4 @@
-initialization
+running
 tearDown
 
 	factory tearDownWithRepository: repository.

--- a/Iceberg-Tests.package/IceCleanWorkingCopyFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceCleanWorkingCopyFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.

--- a/Iceberg-Tests.package/IceCleanWorkingCopyTest.class/properties.json
+++ b/Iceberg-Tests.package/IceCleanWorkingCopyTest.class/properties.json
@@ -5,10 +5,7 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [
-		"packageName1",
-		"packageName2"
-	],
+	"instvars" : [ ],
 	"name" : "IceCleanWorkingCopyTest",
 	"type" : "normal"
 }

--- a/Iceberg-Tests.package/IceDetachedWorkingCopyFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceDetachedWorkingCopyFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	| head |

--- a/Iceberg-Tests.package/IceDirtyDetachedWorkingCopyFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceDirtyDetachedWorkingCopyFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.

--- a/Iceberg-Tests.package/IceGitCleanWorkingCopyTest.class/properties.json
+++ b/Iceberg-Tests.package/IceGitCleanWorkingCopyTest.class/properties.json
@@ -5,10 +5,7 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [
-		"packageName",
-		"projectName"
-	],
+	"instvars" : [ ],
 	"name" : "IceGitCleanWorkingCopyTest",
 	"type" : "normal"
 }

--- a/Iceberg-Tests.package/IceHttpsRemoteTest.class/instance/defaultTestClass.st
+++ b/Iceberg-Tests.package/IceHttpsRemoteTest.class/instance/defaultTestClass.st
@@ -1,4 +1,4 @@
-defaults
+private - defaults
 defaultTestClass
 	"Return the default test class"
 	

--- a/Iceberg-Tests.package/IceMissingLocalRepositoryFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceMissingLocalRepositoryFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.

--- a/Iceberg-Tests.package/IceMultiplePackageFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceMultiplePackageFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.

--- a/Iceberg-Tests.package/IceParameterizedTestCase.class/instance/cleanUpInstanceVariables.st
+++ b/Iceberg-Tests.package/IceParameterizedTestCase.class/instance/cleanUpInstanceVariables.st
@@ -1,5 +1,8 @@
 private
 cleanUpInstanceVariables
-	self class allInstVarNames do: [ :name |
-		(name = 'testSelector' or: [name = 'testParameters']) ifFalse: [
-			self instVarNamed: name put: nil ] ]
+	| instanceVariablesNames |
+	instanceVariablesNames := #('testSeletor' 'testParameters').
+	self class allInstVarNames
+		do: [ :name | 
+			(instanceVariablesNames includes: name)
+				ifFalse: [ self instVarNamed: name put: nil ] ]

--- a/Iceberg-Tests.package/IceParameterizedTestCase.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceParameterizedTestCase.class/instance/setUp.st
@@ -1,6 +1,6 @@
 running
 setUp
+	super setUp.
 	oldShareRepositoriesBetweenImages := IceLibgitRepository shareRepositoriesBetweenImages.
 	IceLibgitRepository shareRepositoriesBetweenImages: false.
-	self parameters do: #activate.
-	
+	self parameters do: #activate

--- a/Iceberg-Tests.package/IceParameterizedTestCase.class/instance/tearDown.st
+++ b/Iceberg-Tests.package/IceParameterizedTestCase.class/instance/tearDown.st
@@ -1,7 +1,9 @@
 running
 tearDown
-	self parameters do: [ :parameter |
-		[ parameter deactivate ] on: Error do: [ :error | error logCr ] ].
-	IceLibgitRepository shareRepositoriesBetweenImages: oldShareRepositoriesBetweenImages
-	
-	
+	self parameters
+		do: [ :parameter | 
+			[ parameter deactivate ]
+				on: Error
+				do: [ :error | error logCr ] ].
+	IceLibgitRepository shareRepositoriesBetweenImages: oldShareRepositoriesBetweenImages.
+	super tearDown

--- a/Iceberg-Tests.package/IceSinglePackageFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceSinglePackageFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.

--- a/Iceberg-Tests.package/IceSinglePackageLocalRepositoryTest.class/instance/testListBranchesListsExistingBranches.st
+++ b/Iceberg-Tests.package/IceSinglePackageLocalRepositoryTest.class/instance/testListBranchesListsExistingBranches.st
@@ -3,5 +3,5 @@ testListBranchesListsExistingBranches
 
 	| branches |
 	branches := self repository allBranches.
-	self assert: branches size = 1.
+	self assert: branches size equals: 1.
 	self assert: branches first name equals: 'master'

--- a/Iceberg-Tests.package/IceTestCase.class/instance/testListBranchesListsExistingBranches.st
+++ b/Iceberg-Tests.package/IceTestCase.class/instance/testListBranchesListsExistingBranches.st
@@ -3,5 +3,5 @@ testListBranchesListsExistingBranches
 
 	| branches |
 	branches := self repository allBranches.
-	self assert: branches size = 1.
+	self assert: branches size equals: 1.
 	self assert: branches first name equals: 'master'

--- a/Iceberg-Tests.package/IceTestCase.class/instance/testListBranchesListsNewBranch.st
+++ b/Iceberg-Tests.package/IceTestCase.class/instance/testListBranchesListsNewBranch.st
@@ -8,7 +8,7 @@ testListBranchesListsNewBranch
 	self repository createBranch: branchName.
 	branches := self repository allBranches.
 	
-	self assert: branches size = 2.
+	self assert: branches size equals: 2.
 	branches
 		detect: [ :branch | branch name = branchName ]
 		ifNone: [ self fail ]

--- a/Iceberg-Tests.package/IceTestCase.class/instance/testListBranchesListsNewBranchWithSlashes.st
+++ b/Iceberg-Tests.package/IceTestCase.class/instance/testListBranchesListsNewBranchWithSlashes.st
@@ -8,7 +8,7 @@ testListBranchesListsNewBranchWithSlashes
 	self repository createBranch: branchName.
 	branches := self repository allBranches.
 	
-	self assert: branches size = 2.
+	self assert: branches size equals: 2.
 	branches
 		detect: [ :branch | branch name = branchName ]
 		ifNone: [ self fail ]

--- a/Iceberg-Tests.package/IceTestDefinition.class/instance/key.st
+++ b/Iceberg-Tests.package/IceTestDefinition.class/instance/key.st
@@ -1,3 +1,0 @@
-accessing
-key
-	^ name

--- a/Iceberg-Tests.package/IceTreeConstructionTests.class/instance/testCreateDirectoryWithPackage.st
+++ b/Iceberg-Tests.package/IceTreeConstructionTests.class/instance/testCreateDirectoryWithPackage.st
@@ -1,7 +1,7 @@
 tests
 testCreateDirectoryWithPackage
 
-	| tree srcDirectory importer child |
+	| tree importer child |
 	tree := IceNode new.
 	child := tree addChild: (IceDirectoryDefinition named: 'src').
 	importer := IceMCPackageImporter new

--- a/Iceberg-Tests.package/IceWithRemoteAndUnknownCommitFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceWithRemoteAndUnknownCommitFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 	super setUp.
 

--- a/Iceberg-Tests.package/IceWithRemoteFixture.class/instance/setUp.st
+++ b/Iceberg-Tests.package/IceWithRemoteFixture.class/instance/setUp.st
@@ -1,4 +1,4 @@
-initialization
+running
 setUp
 
 	super setUp.


### PR DESCRIPTION
- Categorization
- Remove unused variables
- Remove methods equivalent to their super
- Use #assert:equals: instead of #assert: and #=