### PR TITLE
Fixes case when DELETE is returning a 204 No Content, for example usi…

### DIFF
--- a/Iceberg-Plugin-GitHub.package/IceGitHubAPI.class/instance/delete..st
+++ b/Iceberg-Plugin-GitHub.package/IceGitHubAPI.class/instance/delete..st
@@ -1,6 +1,6 @@
 private requesting
 delete: aString 
-	^ self jsonContentsWithValidationDo: [
+	^ self contentsWithValidationDo: [
 		(self newRequestTo: aString)
 			delete;
 			response ]


### PR DESCRIPTION
…ng the API to delete labels in a project.

Fixes #894 .

I have reviewed the senders of `delete:` in the GitHubAPI and no one uses the result.