### PR TITLE
Rename directory label into "code directory"

### DIFF
--- a/Iceberg-TipUI.package/IceTipEditProjectDialog.class/instance/initializeWidgets.st
+++ b/Iceberg-TipUI.package/IceTipEditProjectDialog.class/instance/initializeWidgets.st
@@ -3,7 +3,9 @@ initializeWidgets
 	nameLabel := self newLabel label: 'Project Name'.
 	nameInput := self newLabel label: self model name.
 	
-	sourceDirectoryLabel := self newLabel label: 'Directory'.
+	sourceDirectoryLabel := self newLabel
+		label: 'Code directory';
+		yourself.
 	sourceDirectoryTree := self newIceTreeTable.
 	
 	formatLabel := self newLabel label: 'Format'.


### PR DESCRIPTION
Fix #951Rename directory label into "code directory" in the project edition dialog.