### PR TITLE
issue/967

### DIFF
--- a/Iceberg-Tests.package/IceGitMergeTest.class/instance/testMergeOfInnessaryMergeCommit.st
+++ b/Iceberg-Tests.package/IceGitMergeTest.class/instance/testMergeOfInnessaryMergeCommit.st
@@ -1,0 +1,73 @@
+tests
+testMergeOfInnessaryMergeCommit
+	| c1 c2 c3 c4 i1  fileRef|
+
+	"When producing a merge, sometimes Github produces a merge commit that is not necessary. 
+	This merge commit includes two commits that are also included in the chain of ancestors of the head.
+
+	Initial state:
+
+	(c4) <-- master
+	 | 
+	 |	
+	 | 
+	 v	 
+	(c3) <--(i1) <-- incoming
+	 |       |
+	 v       |
+	(c2)     |
+	 |       |
+	 v       |
+	(c1) <----
+
+	Expected State:
+	
+	(merge)--   <-- master
+	 |       |
+    |       |
+	 v       |
+	(c4)     | 
+	 |       |
+	 |       |	
+	 |       | 
+	 v       v	 
+	(c3) <--(i1) <-- incoming
+	 |       |
+	 v       |
+	(c2)     |
+	 |       |
+	 v       |
+	(c1) <----
+		
+	"
+
+	c1 := self repository commitWithMessage: 'C1'.
+	
+	fileRef := self repository location / 'c2.txt'.
+	fileRef writeStreamDo: [ :stream | stream << 'c2' ].
+	self repository index addPath: (fileRef relativeTo: self repository location).
+	c2 := self repository commitWithMessage: 'C2'.
+
+	fileRef := self repository location / 'c3.txt'.
+	fileRef writeStreamDo: [ :stream | stream << 'c3' ].
+	self repository index addPath: (fileRef relativeTo: self repository location).
+	c3 := self repository commitWithMessage: 'C3'.
+
+	fileRef := self repository location / 'c4.txt'.
+	fileRef writeStreamDo: [ :stream | stream << 'c4' ].
+	self repository index addPath: (fileRef relativeTo: self repository location).
+	c4 := self repository commitWithMessage: 'C4'.
+
+	c3 checkout.
+	self repository checkoutBranch: 'incoming'.
+
+	i1 := self repository
+		commitIndexWithMessage: 'Merge'
+		andParents: {c3. c1}.
+	
+	self repository checkoutBranch: 'master'.
+	
+	i1 merge. 
+	
+	self assert: self repository branch commit ancestors equals: { c4. i1 }.
+	self assert: self repository branch commit comment equals: 'Merge ' , i1 id.

--- a/Iceberg-Tests.package/IceGitMergeTest.class/instance/testMergeWithEmptyIncomingCommitCreatesMergeCommit.st
+++ b/Iceberg-Tests.package/IceGitMergeTest.class/instance/testMergeWithEmptyIncomingCommitCreatesMergeCommit.st
@@ -1,0 +1,20 @@
+tests
+testMergeWithEmptyIncomingCommitCreatesMergeCommit
+	| incomingBranch |
+
+	self repository checkoutBranch: 'master'.	
+	self repository workingCopy project: self repository newUnbornProject.
+	self repository commitWithMessage: 'Remove project file'.
+
+	self repository checkoutBranch: 'localBranch'.
+	self repository workingCopy project: (IceBasicProject onRepository: self repository withSourceDirectory: '').
+	self repository commitWithMessage: 'commit project file'.
+	incomingBranch := self repository branch.
+	
+	self repository checkoutBranch: 'master'.	
+	self repository workingCopy project: (IceBasicProject onRepository: self repository withSourceDirectory: '').
+	self repository commitWithMessage: 'second commit in master'.
+
+	incomingBranch merge.
+		
+	self assert: self repository workingCopy referenceCommit comment equals: 'Merge ' , incomingBranch commit id

--- a/Iceberg-Tests.package/IceGitMergeTest.class/instance/testMergeWithMissingProjectFile.st
+++ b/Iceberg-Tests.package/IceGitMergeTest.class/instance/testMergeWithMissingProjectFile.st
@@ -1,0 +1,25 @@
+tests
+testMergeWithMissingProjectFile
+	| incomingBranch fileRef |
+
+	self repository checkoutBranch: 'master'.	
+	self repository commitWithMessage: 'Initial Commit'.
+
+	self repository checkoutBranch: 'localBranch'.
+	self repository workingCopy project: self repository newUnbornProject.
+	fileRef := self repository location / 'test1.txt'.
+	fileRef writeStreamDo: [ :stream | stream << 'test1' ].
+	self repository index addPath: (fileRef relativeTo: self repository location).
+	self repository commitWithMessage: 'commiting something'.
+	incomingBranch := self repository branch.
+	
+	self repository checkoutBranch: 'master'.	
+	self repository workingCopy project: (IceBasicProject onRepository: self repository withSourceDirectory: '').
+	fileRef := self repository location / 'test2.txt'.
+	fileRef writeStreamDo: [ :stream | stream << 'test2' ].
+	self repository index addPath: (fileRef relativeTo: self repository location).
+	self repository commitWithMessage: 'second commit in master'.
+
+	incomingBranch merge.
+		
+	self assert: self repository workingCopy referenceCommit comment equals: 'Merge ' , incomingBranch commit id

--- a/Iceberg.package/IceMerge.class/instance/updateHead.st
+++ b/Iceberg.package/IceMerge.class/instance/updateHead.st
@@ -17,5 +17,5 @@ updateHead
 				setMergeStateBetweenCommits:
 					{self leftCommit.
 					mergeCommit}.
-			repository workingCopy commitChanges: self withMessage: 'Merge ' , mergeCommit id asString ].
+			repository workingCopy commitChanges: self withMessage: 'Merge ' , mergeCommit id asString force: true ].
 	repository branch commit: commitToAdvance

--- a/Iceberg.package/IceWorkingCopy.class/instance/commitChanges.withMessage..st
+++ b/Iceberg.package/IceWorkingCopy.class/instance/commitChanges.withMessage..st
@@ -1,21 +1,4 @@
 API-commits
 commitChanges: aDiff withMessage: message 
-	"Creates a commit with the given changes using the comment given as argument.
 	
-	NOTICE that commits can only be done if the following is true:
-
- - HEAD is a branch
- - the working copy reference commit is the same commit as #headCommit"
-	
-	| newCommit |
-	self validateCanCommit.
-	self repository index
-		updateDiskWorkingCopy: aDiff;
-		updateIndex: aDiff.
-
-	repository index isEmpty ifTrue: [ IceNothingToCommit signal ].
-
-	newCommit := self repository
-		commitIndexWithMessage: message
-		andParents: (self workingCopyState referenceCommits reject: [ :each | each isNoCommit ]).
-	^ newCommit
+	^ self commitChanges: aDiff withMessage: message force: false

--- a/Iceberg.package/IceWorkingCopy.class/instance/commitChanges.withMessage.force..st
+++ b/Iceberg.package/IceWorkingCopy.class/instance/commitChanges.withMessage.force..st
@@ -1,0 +1,24 @@
+as yet unclassified
+commitChanges: aDiff withMessage: message force: forcing 
+
+	"Creates a commit with the given changes using the comment given as argument.
+	The forcing parameter allows to create an empty commit. This is used by the merge.
+	
+	NOTICE that commits can only be done if the following is true:
+
+ - HEAD is a branch
+ - the working copy reference commit is the same commit as #headCommit"
+
+	| newCommit |
+	self validateCanCommit.
+	self repository index
+		updateDiskWorkingCopy: aDiff;
+		updateIndex: aDiff.
+
+	(forcing not and: [repository index isEmpty]) 
+		ifTrue: [ IceNothingToCommit signal ].
+
+	newCommit := self repository
+		commitIndexWithMessage: message
+		andParents: (self workingCopyState referenceCommits reject: [ :each | each isNoCommit ]).
+	^ newCommit


### PR DESCRIPTION
When producing a merge, sometimes Github produces a merge commit that is not necessary. 
This merge commit includes two commits that are also included in the chain of ancestors of the head.

The merge should always create the commit with the two parents.
Fix #967