### PR TITLE
992-fix-tonel-migration

### DIFF
--- a/Iceberg-Libgit.package/IceLibgitRepository.class/instance/mcVersionFor..st
+++ b/Iceberg-Libgit.package/IceLibgitRepository.class/instance/mcVersionFor..st
@@ -1,9 +1,10 @@
 private-monticello
 mcVersionFor: iceVersion
 	[ | commit |
-	commit := iceVersion commit libgitCommit.
-	^ (iceVersion commit readerClass on: commit iceVersion: iceVersion) version ]
-		on: IceMissingRepositoryEntry , LGit_GIT_ENOTFOUND
-		do: [ IceVersionDoesNotExist new
-				version: iceVersion;
-				signal ]
+		commit := iceVersion commit libgitCommit.
+		^ (iceVersion commit readerClass on: commit iceVersion: iceVersion) version ]
+	on: IceMissingRepositoryEntry, LGit_GIT_ENOTFOUND
+	do: [ 
+		IceVersionDoesNotExist new
+			version: iceVersion;
+			signal ]

--- a/Iceberg-Plugin-Migration.package/IceConvertFormatAction.class/instance/ensureMCVersionWithClassOrganisation..st
+++ b/Iceberg-Plugin-Migration.package/IceConvertFormatAction.class/instance/ensureMCVersionWithClassOrganisation..st
@@ -1,0 +1,16 @@
+private
+ensureMCVersionWithClassOrganisation: mcVersion
+	"if a package does not has class organisation (happens when package is composed 
+	 only for extensions, we need to ensure it has one, otherwise package creation will 
+	 fail"
+
+	^ mcVersion snapshot definitions 
+		detect: [ :each | each isClassDefinition ]
+		ifFound: [ :each | mcVersion ]
+		ifNone: [ 
+			MCVersion 
+				package: mcVersion package
+				info: mcVersion info
+				snapshot: (MCSnapshot fromDefinitions: (
+					{ MCOrganizationDefinition categories: { mcVersion package name }}, 
+					mcVersion snapshot definitions)) ]

--- a/Iceberg-Plugin-Migration.package/IceConvertFormatAction.class/instance/migratePackage.commit..st
+++ b/Iceberg-Plugin-Migration.package/IceConvertFormatAction.class/instance/migratePackage.commit..st
@@ -1,13 +1,17 @@
 private
-migratePackage: each commit: commit
-	| filetreePackage srcDir subDirWithDelim |
+migratePackage: packageName commit: commit
+	| filetreePackage srcDir subDirWithDelim mcVersion |
 	
 	srcDir := self codeDirectory.
 	subDirWithDelim := self codeDirectoryWithDelim.
 	
-	self writerClass forInternalStoreFileOut: (commit versionFor: each) mcVersion on: repository.
-	filetreePackage := commit writerClass directoryNameFor: each.
+	mcVersion := (commit versionFor: packageName) mcVersion.
+	mcVersion := self ensureMCVersionWithClassOrganisation: mcVersion.
+	self writerClass 
+		forInternalStoreFileOut: mcVersion 
+		on: repository.
+	filetreePackage := commit writerClass directoryNameFor: packageName.
 	(srcDir / filetreePackage) ensureDeleteAll.
 	self repository addFilesToIndex: { 
-		subDirWithDelim, (IceLibgitTonelWriter directoryNameFor: each).
-		subDirWithDelim, (IceLibgitFiletreeWriter directoryNameFor: each) }
+		subDirWithDelim, (IceLibgitTonelWriter directoryNameFor: packageName).
+		subDirWithDelim, (IceLibgitFiletreeWriter directoryNameFor: packageName) }


### PR DESCRIPTION
ensures a class organisation is always present when converting a package.

Fixes #992