### PR TITLE
Improved new tag dialog

### DIFF
--- a/Iceberg-TipUI.package/IceTipCreateTagCommand.class/class/defaultMenuItemName.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagCommand.class/class/defaultMenuItemName.st
@@ -1,3 +1,3 @@
 activation
 defaultMenuItemName
-	^ 'Create Tag'
+	^ 'Create tag'

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/class/defaultSpec.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/class/defaultSpec.st
@@ -1,14 +1,20 @@
 specs
 defaultSpec
 	<spec: #default>
-
-	^ SpecLayout composed 
+	^ SpecLayout composed
 		newColumn: [ :col | 
 			col
 				newRow: #currentCommitishLabel height: self inputTextHeight;
 				newRow: [ :row | 
-						row 
-							add: #tagNameLabel width: self iceLabelWidth;
-							add: #tagNameInputText ]
+					row
+						add: #tagNameLabel width: self iceLabelWidth;
+						add: #tagNameInputText ]
 					height: self inputTextHeight;
+				newRow: [ :row | 
+					row
+						add: #majorButton;
+						add: #minorButton;
+						add: #patchButton ]
+					height: self inputTextHeight;
+				newRow: #existingTagsList height: self inputTextHeight * 3;
 				newRow: #spacePanel ]

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/class/title.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/class/title.st
@@ -1,3 +1,3 @@
 specs
 title
-	^ 'New branch'
+	^ 'New tag'

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/existingTagsList.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/existingTagsList.st
@@ -1,0 +1,3 @@
+accessing ui
+existingTagsList
+	^ existingTagsList

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeCurrentBranchLabel.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeCurrentBranchLabel.st
@@ -1,4 +1,4 @@
 initialization
 initializeCurrentBranchLabel
 	currentCommitishLabel := self newLabel
-		label: 'Current commith: ' , commitishToTag commit shortId
+		label: 'Current commit: ' , commitishToTag commit shortId

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeExistingTagsList.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeExistingTagsList.st
@@ -1,0 +1,7 @@
+initialization
+initializeExistingTagsList
+	existingTagsList := self newList.
+	existingTagsList
+		items: commitishToTag tagModels;
+		displayBlock: #name;
+		sortingBlock: #name descending

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeNextTagPanel.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeNextTagPanel.st
@@ -1,0 +1,21 @@
+initialization
+initializeNextTagPanel
+	| parts prefix nextMajor nextMinor nextPatch toString |
+	parts := self latestTagParts.
+	prefix := parts first.
+	parts := parts allButFirst.
+	toString := [ :arr | (arr collect: #asString) joinUsing: '.' ].
+	nextMajor := prefix , (toString value: (Array with: parts first + 1 with: 0 with: 0)).
+	nextMinor := prefix
+		, (toString value: (Array with: parts first with: parts second + 1 with: 0)).
+	nextPatch := prefix
+		, (toString value: (Array with: parts first with: parts second with: parts third + 1)).
+	majorButton := self newButton
+		label: 'major (' , nextMajor , ')';
+		action: [ tagNameInputText text: nextMajor ].
+	minorButton := self newButton
+		label: 'minor (' , nextMinor , ')';
+		action: [ tagNameInputText text: nextMinor ].
+	patchButton := self newButton
+		label: 'patch (' , nextPatch , ')';
+		action: [ tagNameInputText text: nextPatch ]

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeWidgetsContents.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/initializeWidgetsContents.st
@@ -5,4 +5,6 @@ initializeWidgetsContents
 	tagNameInputText := self newTextInput
 		autoAccept: true;
 		ghostText: 'e.g., v[X].[Y].[Z]'.
+	self initializeNextTagPanel.
+	self initializeExistingTagsList.
 	spacePanel := PanelMorph new asSpecAdapter

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/latestTagParts.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/latestTagParts.st
@@ -1,0 +1,3 @@
+accessing
+latestTagParts
+	^ self latestTagPartsIn: (commitishToTag tagModels collect: #name)

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/latestTagPartsIn..st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/latestTagPartsIn..st
@@ -1,0 +1,16 @@
+accessing
+latestTagPartsIn: tagNames
+	| prefix parts |
+	"Find the highest numeric version with optional 'v' prefix. Set any missing parts to 0. For proper comparison (build data, prerelease, etc.), a Semver library is needed."
+	parts := #('v' 0 0 0).
+	prefix := 'v'.
+	(tagNames select: [ :each | 'v?[0-9]' asRegex matchesPrefix: each ])
+		ifNotEmpty: [ :tags | 
+			| latestTag |
+			latestTag := tags sorted last.
+			parts := ((latestTag beginsWith: prefix)
+				ifTrue: [ #('v') ]
+				ifFalse: [ #('') ])
+				, ((((latestTag withoutPrefix: prefix) copyUpTo: $-) splitOn: '.') collect: #asNumber).
+			parts := parts , (#(0 0 0) first: 4 - parts size) ].
+	^ parts

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/latestTagPartsIn..st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/latestTagPartsIn..st
@@ -11,6 +11,8 @@ latestTagPartsIn: tagNames
 			parts := ((latestTag beginsWith: prefix)
 				ifTrue: [ #('v') ]
 				ifFalse: [ #('') ])
-				, ((((latestTag withoutPrefix: prefix) copyUpTo: $-) splitOn: '.') collect: #asNumber).
+				,
+					((((latestTag withoutPrefix: prefix) copyUpTo: $-) splitOn: '.')
+						collect: [ :each | NumberParser parse: each onError: [ 0 ] ]).
 			parts := parts , (#(0 0 0) first: 4 - parts size) ].
 	^ parts

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/majorButton.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/majorButton.st
@@ -1,0 +1,3 @@
+accessing ui
+majorButton
+	^ majorButton

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/minorButton.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/minorButton.st
@@ -1,0 +1,3 @@
+accessing ui
+minorButton
+	^ minorButton

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/patchButton.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/patchButton.st
@@ -1,0 +1,3 @@
+accessing ui
+patchButton
+	^ patchButton

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/title.st
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/instance/title.st
@@ -1,0 +1,3 @@
+api
+title
+	^ 'New tag of ' , commitishToTag name

--- a/Iceberg-TipUI.package/IceTipCreateTagPanel.class/properties.json
+++ b/Iceberg-TipUI.package/IceTipCreateTagPanel.class/properties.json
@@ -12,7 +12,11 @@
 		"commitishToTag",
 		"currentCommitishLabel",
 		"tagNameLabel",
-		"acceptBlock"
+		"acceptBlock",
+		"existingTagsList",
+		"majorButton",
+		"minorButton",
+		"patchButton"
 	],
 	"name" : "IceTipCreateTagPanel",
 	"type" : "normal"

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsNoNumeric.st
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsNoNumeric.st
@@ -1,0 +1,5 @@
+tests
+testLatestTagPartsNoNumeric
+	panel := IceTipCreateTagPanel basicNew.
+	self assert: (panel latestTagPartsIn: #()) equals: #('v' 0 0 0).
+	self assert: (panel latestTagPartsIn: #('non-numeric')) equals: #('v' 0 0 0)

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsNoNumeric2.st
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsNoNumeric2.st
@@ -1,0 +1,5 @@
+tests
+testLatestTagPartsNoNumeric2
+	panel := IceTipCreateTagPanel basicNew.
+	self assert: (panel latestTagPartsIn: #('v1.2.x')) equals: #('v' 1 2 0).
+	self assert: (panel latestTagPartsIn: #('v1.x')) equals: #('v' 1 0 0).

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsPadded.st
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsPadded.st
@@ -1,0 +1,4 @@
+tests
+testLatestTagPartsPadded
+	panel := IceTipCreateTagPanel basicNew.
+	self assert: (panel latestTagPartsIn: #('v2.1')) equals: #('v' 2 1 0)

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsWithExtra.st
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsWithExtra.st
@@ -1,0 +1,6 @@
+tests
+testLatestTagPartsWithExtra
+	panel := IceTipCreateTagPanel basicNew.
+	self
+		assert: (panel latestTagPartsIn: #('v1.0.0-alpha+001' 'v1.0.3+20130313144700'))
+		equals: #('v' 1 0 3)

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsWithPrefix.st
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsWithPrefix.st
@@ -1,0 +1,6 @@
+tests
+testLatestTagPartsWithPrefix
+	panel := IceTipCreateTagPanel basicNew.
+	self
+		assert: (panel latestTagPartsIn: #('v2.1.2' 'v2.1.3' '3.1.7' '4.0.0' 'non-numeric'))
+		equals: #('v' 2 1 3)

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsWithoutPrefix.st
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/instance/testLatestTagPartsWithoutPrefix.st
@@ -1,0 +1,6 @@
+tests
+testLatestTagPartsWithoutPrefix
+	panel := IceTipCreateTagPanel basicNew.
+	self
+		assert: (panel latestTagPartsIn: #('3.1.7' '4.0.0' 'non-numeric'))
+		equals: #('' 4 0 0)

--- a/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/properties.json
+++ b/Iceberg-UI-Tests.package/IceTipCreateTagPanelTest.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Iceberg-UI-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"panel"
+	],
+	"name" : "IceTipCreateTagPanelTest",
+	"type" : "normal"
+}


### PR DESCRIPTION
Added buttons to create next logical semantic versions and the listing of current tags.

As there is no Semver library for pharo (afaik), the version extraction is freehanded (but I've added tests for that).

![image](https://user-images.githubusercontent.com/1276328/46916055-77c17f00-cfb5-11e8-8ff0-d550acfbb801.png)
