### PR TITLE
1036-Debugger-if-we-try-to-merge-without-selecting-a-branch

### DIFF
--- a/Iceberg-TipUI.package/IceTipBranchModel.class/instance/printOn..st
+++ b/Iceberg-TipUI.package/IceTipBranchModel.class/instance/printOn..st
@@ -1,0 +1,7 @@
+printing
+printOn: aStream
+	super printOn: aStream.
+	aStream
+		nextPut: $[;
+		nextPutAll: self name;
+		nextPut: $]

--- a/Iceberg-TipUI.package/IceTipCachedModel.class/instance/printOn..st
+++ b/Iceberg-TipUI.package/IceTipCachedModel.class/instance/printOn..st
@@ -1,0 +1,6 @@
+printing
+printOn: aStream
+	super printOn: aStream.
+	aStream nextPut: $(.
+	self realObject printOn: aStream.
+	aStream nextPut: $)

--- a/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/initializeBranchesList.st
+++ b/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/initializeBranchesList.st
@@ -1,7 +1,10 @@
 initialization
 initializeBranchesList
+	| dataSource |
 	branchesList widget
 		addColumn: (IceTipTableColumn newAction: #shortDescriptionWithDecoration);
-		dataSource: self newBranchListDataSource;
+		dataSource: (dataSource := self newBranchListDataSource);
 		bindKeyCombination: Character cr toAction: [ self accept ];
-		onAnnouncement: FTStrongSelectionChanged do: [ self accept ]
+		onAnnouncement: FTStrongSelectionChanged do: [ self accept ].
+
+	self model branchModels detect: #isHead ifFound: [ :head | branchesList widget selectRowIndex: (dataSource elements indexOf: head) ] ifNone: [ self model hasBranches ifTrue: [ branchesList widget selectFirstVisibleRow ] ]

--- a/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/initializeBranchesList.st
+++ b/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/initializeBranchesList.st
@@ -6,5 +6,10 @@ initializeBranchesList
 		dataSource: (dataSource := self newBranchListDataSource);
 		bindKeyCombination: Character cr toAction: [ self accept ];
 		onAnnouncement: FTStrongSelectionChanged do: [ self accept ].
-
+	
+	"
+	We would prefere to have this implementation but for now we have a bug with the caches because #branchModels return the same cache used by the datasource but not #defaultBranchSelection. If we correct that later we can clean the code bellow.
+	
+	self model defaultBranchSelection ifNotNil: [ :branchModel | branchesList widget selectRowIndex: (dataSource elements indexOf: branchModel) ]."
+	
 	self model branchModels detect: #isHead ifFound: [ :head | branchesList widget selectRowIndex: (dataSource elements indexOf: head) ] ifNone: [ self model hasBranches ifTrue: [ branchesList widget selectFirstVisibleRow ] ]

--- a/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/validate.st
+++ b/Iceberg-TipUI.package/IceTipExistingBranchPanel.class/instance/validate.st
@@ -1,5 +1,3 @@
 accessing
 validate
-	self 
-		assert: self selectedBranch isNotNil 
-		description: 'Please select a branch to checkout.'
+	self selectedBranch ifNil: [ IceError signal: 'Please select a branch to checkout.' ]

--- a/Iceberg-TipUI.package/IceTipMergeBranchPanel.class/instance/doAccept.st
+++ b/Iceberg-TipUI.package/IceTipMergeBranchPanel.class/instance/doAccept.st
@@ -1,6 +1,7 @@
 actions
 doAccept
-
+	self validate.
+	
 	IceTipStandardAction new 
 		repository: self model entity; 
 		message: ('Verifying merge from {1}' format: { self selectedBranch name });

--- a/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/branchModels.st
+++ b/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/branchModels.st
@@ -1,8 +1,0 @@
-accessing
-branchModels
-	^ self entity branches 
-		collect: [ :each | 
-			(IceTipBranchModel 
-				repositoryModel: self repositoryModel 
-				on: each) 
-				beCached ]

--- a/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/branches.st
+++ b/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/branches.st
@@ -1,0 +1,3 @@
+accessing
+branches
+	^ self entity branches

--- a/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/hasBranches.st
+++ b/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/hasBranches.st
@@ -1,0 +1,3 @@
+testing
+hasBranches 
+	^ self entity hasBranches

--- a/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/hasBranches.st
+++ b/Iceberg-TipUI.package/IceTipRemoteModel.class/instance/hasBranches.st
@@ -1,3 +1,0 @@
-testing
-hasBranches 
-	^ self entity hasBranches

--- a/Iceberg-TipUI.package/IceTipRemoteModel.class/properties.json
+++ b/Iceberg-TipUI.package/IceTipRemoteModel.class/properties.json
@@ -1,11 +1,13 @@
 {
-	"commentStamp" : "EstebanLorenzano 5/30/2018 14:33",
-	"super" : "IceTipEntityModel",
-	"category" : "Iceberg-TipUI-Model",
-	"classinstvars" : [ ],
-	"pools" : [ ],
+	"classtraitcomposition" : "TWithBranchModel classTrait",
 	"classvars" : [ ],
 	"instvars" : [ ],
 	"name" : "IceTipRemoteModel",
-	"type" : "normal"
+	"commentStamp" : "EstebanLorenzano 5/30/2018 14:33",
+	"super" : "IceTipEntityModel",
+	"traitcomposition" : "TWithBranchModel",
+	"type" : "normal",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"category" : "Iceberg-TipUI-Model"
 }

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branchModels.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branchModels.st
@@ -1,8 +1,0 @@
-accessing
-branchModels
-	^ self entity localBranches
-		collect: [ :each | 
-			(IceTipBranchModel 
-				repositoryModel: self 
-				on: each) 
-				beCached ]

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branches.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/branches.st
@@ -1,0 +1,3 @@
+accessing
+branches
+	^ self entity localBranches

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/hasBranches.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/hasBranches.st
@@ -1,3 +1,0 @@
-testing
-hasBranches
-	^ self entity hasLocalBraches

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/hasBranches.st
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/instance/hasBranches.st
@@ -1,0 +1,3 @@
+testing
+hasBranches
+	^ self entity hasLocalBraches

--- a/Iceberg-TipUI.package/IceTipRepositoryModel.class/properties.json
+++ b/Iceberg-TipUI.package/IceTipRepositoryModel.class/properties.json
@@ -1,11 +1,11 @@
 {
-	"classtraitcomposition" : "TIceCopyCommitId classTrait",
+	"classtraitcomposition" : "TIceCopyCommitId classTrait + TWithBranchModel classTrait",
 	"classvars" : [ ],
 	"instvars" : [ ],
 	"name" : "IceTipRepositoryModel",
 	"commentStamp" : "EstebanLorenzano 5/30/2018 14:33",
 	"super" : "IceTipEntityModel",
-	"traitcomposition" : "TIceCopyCommitId",
+	"traitcomposition" : "TIceCopyCommitId + TWithBranchModel",
 	"type" : "normal",
 	"classinstvars" : [ ],
 	"pools" : [ ],

--- a/Iceberg-TipUI.package/TWithBranchModel.trait/instance/branchModels.st
+++ b/Iceberg-TipUI.package/TWithBranchModel.trait/instance/branchModels.st
@@ -1,0 +1,3 @@
+branches
+branchModels
+	^ self branches collect: [ :each | (IceTipBranchModel repositoryModel: self repositoryModel on: each) beCached ]

--- a/Iceberg-TipUI.package/TWithBranchModel.trait/instance/branches.st
+++ b/Iceberg-TipUI.package/TWithBranchModel.trait/instance/branches.st
@@ -1,0 +1,3 @@
+branches
+branches
+	^ self explicitRequirement

--- a/Iceberg-TipUI.package/TWithBranchModel.trait/instance/defaultBranchSelection.st
+++ b/Iceberg-TipUI.package/TWithBranchModel.trait/instance/defaultBranchSelection.st
@@ -1,0 +1,6 @@
+accessing
+defaultBranchSelection
+	^ self branchModels
+		detect: #isHead
+		ifNone: [ self hasBranches
+				ifTrue: [ self branchModels ifNotEmpty: #anyOne ] ]

--- a/Iceberg-TipUI.package/TWithBranchModel.trait/instance/hasBranches.st
+++ b/Iceberg-TipUI.package/TWithBranchModel.trait/instance/hasBranches.st
@@ -1,0 +1,3 @@
+testing
+hasBranches 
+	^ self branches isNotEmpty

--- a/Iceberg-TipUI.package/TWithBranchModel.trait/instance/repositoryModel.st
+++ b/Iceberg-TipUI.package/TWithBranchModel.trait/instance/repositoryModel.st
@@ -1,0 +1,3 @@
+accessing
+repositoryModel 
+	^ self explicitRequirement

--- a/Iceberg-TipUI.package/TWithBranchModel.trait/properties.json
+++ b/Iceberg-TipUI.package/TWithBranchModel.trait/properties.json
@@ -1,0 +1,7 @@
+{
+	"commentStamp" : "",
+	"classinstvars" : [ ],
+	"category" : "Iceberg-TipUI-Model",
+	"instvars" : [ ],
+	"name" : "TWithBranchModel"
+}

--- a/Iceberg.package/IceRemote.class/instance/hasBranches.st
+++ b/Iceberg.package/IceRemote.class/instance/hasBranches.st
@@ -1,0 +1,3 @@
+testing
+hasBranches
+	^ self branches isNotEmpty


### PR DESCRIPTION
Improve robustess and UX of merge dialog

- Do no throw a MNU if there is no selected branch
- Select a branch by default if there is one present (either the head of the first one)

Fixes #1036