### PR TITLE
For Pharo 70 iceberg should not be shipped using deprecated class

### DIFF
--- a/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/checkoutShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/checkoutShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 checkoutShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipBranchContext
+	^ CmdShortcutActivation by: $s meta for: IceTipBranchContext

--- a/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/commitShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/commitShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 commitShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipCommitContext
+	^ CmdShortcutActivation by: $s meta for: IceTipCommitContext

--- a/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/pullShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/pullShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 pullShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipPullContext
+	^ CmdShortcutActivation by: $s meta for: IceTipPullContext

--- a/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/pushShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipAcceptCommand.class/class/pushShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 pushShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipPushContext
+	^ CmdShortcutActivation by: $s meta for: IceTipPushContext

--- a/Iceberg-TipUI.package/IceTipAddPackageCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipAddPackageCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ accessing
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $n meta for: IceTipWorkingCopyContext
+	^ CmdShortcutActivation by: $n meta for: IceTipWorkingCopyContext

--- a/Iceberg-TipUI.package/IceTipAddRepositoryCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipAddRepositoryCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $n meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $n meta for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipBrowseCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipBrowseCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $b meta for: IceTipDiffContext
+	^ CmdShortcutActivation by: $b meta for: IceTipDiffContext

--- a/Iceberg-TipUI.package/IceTipBrowsePackageCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipBrowsePackageCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $b meta for: IceTipWorkingCopyContext
+	^ CmdShortcutActivation by: $b meta for: IceTipWorkingCopyContext

--- a/Iceberg-TipUI.package/IceTipCommitCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipCommitCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $s meta for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipCommitCommand.class/class/packageListShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipCommitCommand.class/class/packageListShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 packageListShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipWorkingCopyContext
+	^ CmdShortcutActivation by: $s meta for: IceTipWorkingCopyContext

--- a/Iceberg-TipUI.package/IceTipEditCredentialCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipEditCredentialCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ accessing
 browserShortcutActivation
 	<classAnnotation>
 
-	^ CmdShortcutCommandActivation by: $e meta for: IceTipCredentialContext
+	^ CmdShortcutActivation by: $e meta for: IceTipCredentialContext

--- a/Iceberg-TipUI.package/IceTipFetchCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipFetchCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 browserShortcutActivation
 	"<classAnnotation>"
 	
-	^ CmdShortcutCommandActivation by: $s meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $s meta for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipForgetRepositoryCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipForgetRepositoryCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $x meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $x meta for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipManagePackagesCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipManagePackagesCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ accessing
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $p meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $p meta for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipManageRepositoryCommand.class/class/packageListShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipManageRepositoryCommand.class/class/packageListShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 packageListShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $r meta for: IceTipWorkingCopyContext
+	^ CmdShortcutActivation by: $r meta for: IceTipWorkingCopyContext

--- a/Iceberg-TipUI.package/IceTipManageRepositoryCommand.class/class/repositoryListShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipManageRepositoryCommand.class/class/repositoryListShortcutActivation.st
@@ -2,4 +2,4 @@ activation
 repositoryListShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $r meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $r meta for: IceTipRepositoryListContext

--- a/Iceberg-TipUI.package/IceTipRemoveCredentialCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipRemoveCredentialCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ accessing
 browserShortcutActivation
 	<classAnnotation>
 
-	^ CmdShortcutCommandActivation by: $x meta for: IceTipCredentialContext
+	^ CmdShortcutActivation by: $x meta for: IceTipCredentialContext

--- a/Iceberg-TipUI.package/IceTipSettingsCommand.class/class/browserShortcutActivation.st
+++ b/Iceberg-TipUI.package/IceTipSettingsCommand.class/class/browserShortcutActivation.st
@@ -2,4 +2,4 @@ accessing
 browserShortcutActivation
 	<classAnnotation>
 	
-	^ CmdShortcutCommandActivation by: $n meta for: IceTipRepositoryListContext
+	^ CmdShortcutActivation by: $n meta for: IceTipRepositoryListContext


### PR DESCRIPTION
For Pharo 70 iceberg should not be shipped using deprecated class
#1058 opened 31 seconds ago by Ducasse  https://pharo.fogbugz.com/f/cases/22612/No-DeprecatedClass-use-Iceberg-Command-use-deprecated-CmdMenuActionContext-something