### PR TITLE
1061-Introduce-iconNamed-in-IceDefinition-and-IceTipModel-and-remove-all-the-terrible-Smalltalk-ui-icons

### DIFF
--- a/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestDataSource.class/instance/iconForStatus..st
+++ b/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestDataSource.class/instance/iconForStatus..st
@@ -1,7 +1,3 @@
 private
 iconForStatus: status
-	status = 'success' ifTrue: [ ^ self iconNamed: #testGreen ].
-	status = 'failure' ifTrue: [ ^ self iconNamed: #testRed ].
-	status = 'pending' ifTrue: [ ^ self iconNamed: #testYellow ].
-	
-	^ self iconNamed: #testNotRun
+	^ self iconNamed: (self iconNameForStatus: status)

--- a/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestDataSource.class/instance/iconNameForStatus..st
+++ b/Iceberg-Plugin-GitHub.package/IceGitHubPullRequestDataSource.class/instance/iconNameForStatus..st
@@ -1,0 +1,7 @@
+private
+iconNameForStatus: status
+	status = 'success' ifTrue: [ ^ #testGreen ].
+	status = 'failure' ifTrue: [ ^ #testRed ].
+	status = 'pending' ifTrue: [ ^ #testYellow ].
+	
+	^ #testNotRun

--- a/Iceberg-Plugin-GitHub.package/IceNewBranchFromGitHubIssueCommand.class/class/defaultMenuIconName.st
+++ b/Iceberg-Plugin-GitHub.package/IceNewBranchFromGitHubIssueCommand.class/class/defaultMenuIconName.st
@@ -1,3 +1,3 @@
 testing
 defaultMenuIconName
-	^ #branch
+	^ #github

--- a/Iceberg-Plugin-GitHub.package/IceNewBranchFromGitHubIssueCommand.class/instance/defaultMenuIcon.st
+++ b/Iceberg-Plugin-GitHub.package/IceNewBranchFromGitHubIssueCommand.class/instance/defaultMenuIcon.st
@@ -1,4 +1,0 @@
-execution
-defaultMenuIcon
-
-	^ self iconNamed: #github

--- a/Iceberg-Plugin-Pharo.package/IcePharoMenuGroup.class/instance/icon.st
+++ b/Iceberg-Plugin-Pharo.package/IcePharoMenuGroup.class/instance/icon.st
@@ -1,4 +1,4 @@
 accessing
 icon
 
-	^ (Smalltalk ui iconNamed: #pharo) scaledToSize: 16@16
+	^ (Smalltalk ui icons iconNamed: #pharo) scaledToSize: 16@16

--- a/Iceberg-Plugin-Pharo.package/IcePharoMenuGroup.class/instance/icon.st
+++ b/Iceberg-Plugin-Pharo.package/IcePharoMenuGroup.class/instance/icon.st
@@ -1,4 +1,3 @@
 accessing
 icon
-
-	^ (Smalltalk ui icons iconNamed: #pharo) scaledToSize: 16@16
+	^ (self iconNamed: #pharo) scaledToSize: 16 @ 16

--- a/Iceberg-Plugin-Pharo.package/IceTipNewBranchFromIssueCommand.class/class/defaultMenuIconName.st
+++ b/Iceberg-Plugin-Pharo.package/IceTipNewBranchFromIssueCommand.class/class/defaultMenuIconName.st
@@ -1,3 +1,3 @@
 testing
 defaultMenuIconName
-	^ #branch
+	^ #pharo

--- a/Iceberg-Plugin-Pharo.package/IceTipNewBranchFromIssueCommand.class/instance/defaultMenuIcon.st
+++ b/Iceberg-Plugin-Pharo.package/IceTipNewBranchFromIssueCommand.class/instance/defaultMenuIcon.st
@@ -1,4 +1,0 @@
-execution
-defaultMenuIcon
-
-	^ (Smalltalk ui iconNamed: #pharo) scaledToSize: 16@16

--- a/Iceberg-TipUI.package/IceClassDefinition.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/IceClassDefinition.extension/instance/icon.st
@@ -1,4 +1,3 @@
 *Iceberg-TipUI
 icon
-
-	^ Smalltalk ui icons iconNamed: #class
+	^ self iconNamed: #class

--- a/Iceberg-TipUI.package/IceConflictingOperation.extension/instance/operationIcon.st
+++ b/Iceberg-TipUI.package/IceConflictingOperation.extension/instance/operationIcon.st
@@ -1,4 +1,3 @@
 *Iceberg-TipUI
 operationIcon
-	
-	^ Smalltalk ui icons iconNamed: #changeUpdate
+	^ self iconNamed: #changeUpdate

--- a/Iceberg-TipUI.package/IceDefinition.extension/instance/iconNamed..st
+++ b/Iceberg-TipUI.package/IceDefinition.extension/instance/iconNamed..st
@@ -1,0 +1,3 @@
+*Iceberg-TipUI
+iconNamed: aSymbol
+	^ Smalltalk ui icons iconNamed: aSymbol

--- a/Iceberg-TipUI.package/IceExtensionDefinition.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/IceExtensionDefinition.extension/instance/icon.st
@@ -1,4 +1,3 @@
 *Iceberg-TipUI
 icon
-
-	^ Smalltalk ui icons iconNamed: #group
+	^ self iconNamed: #group

--- a/Iceberg-TipUI.package/IceOperationMerge.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/IceOperationMerge.extension/instance/icon.st
@@ -1,8 +1,7 @@
 *Iceberg-TipUI
 icon
 
-	self isRightChosen ifTrue: [ 
-		^ Smalltalk ui icons iconNamed: #changeBlock ].
-	self isLeftChosen ifTrue: [ 
-		^ Smalltalk ui icons iconNamed: #forward ].
+	self isRightChosen ifTrue: [ ^ self iconNamed: #changeBlock ].
+	self isLeftChosen ifTrue: [ ^ self iconNamed: #forward ].
+	
 	^ self operationIcon

--- a/Iceberg-TipUI.package/IcePackageDefinition.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/IcePackageDefinition.extension/instance/icon.st
@@ -1,4 +1,3 @@
 *Iceberg-TipUI
 icon
-	
-	^ Smalltalk ui icons iconNamed: #dirtyMonticelloPackage
+	^ self iconNamed: #dirtyMonticelloPackage

--- a/Iceberg-TipUI.package/IceTipAction.class/class/iconNamed..st
+++ b/Iceberg-TipUI.package/IceTipAction.class/class/iconNamed..st
@@ -1,0 +1,3 @@
+accessing
+iconNamed: aSymbol
+	^ Smalltalk ui icons iconNamed: aSymbol

--- a/Iceberg-TipUI.package/IceTipBrowser.class/instance/iconNamed..st
+++ b/Iceberg-TipUI.package/IceTipBrowser.class/instance/iconNamed..st
@@ -1,0 +1,3 @@
+accessing
+iconNamed: aSymbol
+	^ Smalltalk ui icons iconNamed: aSymbol

--- a/Iceberg-TipUI.package/IceTipComposablePresenter.class/class/iconNamed..st
+++ b/Iceberg-TipUI.package/IceTipComposablePresenter.class/class/iconNamed..st
@@ -1,0 +1,3 @@
+accessing
+iconNamed: aSymbol
+	^ Smalltalk ui icons iconNamed: aSymbol

--- a/Iceberg-TipUI.package/IceTipComposablePresenter.class/instance/iconNamed..st
+++ b/Iceberg-TipUI.package/IceTipComposablePresenter.class/instance/iconNamed..st
@@ -1,0 +1,3 @@
+accessing
+iconNamed: aSymbol
+	^ self class iconNamed: aSymbol

--- a/Iceberg-TipUI.package/IceTraitDefinition.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/IceTraitDefinition.extension/instance/icon.st
@@ -1,4 +1,3 @@
 *Iceberg-TipUI
 icon
-
-	^ Smalltalk ui icons iconNamed: #trait
+	^ self iconNamed: #trait

--- a/Iceberg-TipUI.package/MCAddition.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/MCAddition.extension/instance/icon.st
@@ -1,3 +1,3 @@
 *Iceberg-TipUI
 icon
-	^ Smalltalk ui icons iconNamed: #changeAdd
+	^ self iconNamed: #changeAdd

--- a/Iceberg-TipUI.package/MCModification.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/MCModification.extension/instance/icon.st
@@ -1,3 +1,3 @@
 *Iceberg-TipUI
 icon
-	^ Smalltalk ui icons iconNamed: #changeUpdate
+	^ self iconNamed: #changeUpdate

--- a/Iceberg-TipUI.package/MCRemoval.extension/instance/icon.st
+++ b/Iceberg-TipUI.package/MCRemoval.extension/instance/icon.st
@@ -1,3 +1,3 @@
 *Iceberg-TipUI
 icon
-	^ Smalltalk ui icons iconNamed: #changeRemove
+	^ self iconNamed: #changeRemove

--- a/Iceberg.package/Iceberg.class/class/settingsOn..st
+++ b/Iceberg.package/Iceberg.class/class/settingsOn..st
@@ -1,27 +1,16 @@
 settings
-settingsOn: aBuilder 
+settingsOn: aBuilder
 	<systemsettings>
 	(aBuilder group: #Iceberg)
 		parent: #SCM;
-		with: [ 
-			(aBuilder setting: #enableMetacelloIntegration)
+		with: [ (aBuilder setting: #enableMetacelloIntegration)
 				target: self;
 				order: 0.1;
 				label: 'Enable Metacello integration';
 				description: 'If selected, Metacello github:// repositories will be loaded using iceberg';
-"				icon: (Smalltalk ui icons iconNamed: #smallConfigurationIcon);"
-				with: [ 
-					(aBuilder pickOne: #remoteTypeSelector)
+				with: [ (aBuilder pickOne: #remoteTypeSelector)
 						label: 'Remote type';
 						description: 'When creating an Iceberg repository out of a github:// URL choose whether you want to user an SCP URL (i.e. with the form ''git@github.com:<username>/<project>.git'') or an HTTPS URL (i.e. with the form ''https://github.com/<username>/<project>.git''';
-						domainValues: {
-							'SCP (git@github.com:<username>/<project>.git)' -> #scpUrl.
-							'HTTPS (https://github.com/<username>/<project>.git)' -> #httpsUrl
-						}.
-				].
-			"(aBuilder setting: #showSystemRepositories) 
-				order: 0.2;
-				label: 'Include system repositories by default';
-				description: 'If checked then system repositories (like ''pharo'') will be shown in repositories list by default';
-				target: self."
-		]
+						domainValues:
+							{('SCP (git@github.com:<username>/<project>.git)' -> #scpUrl).
+							('HTTPS (https://github.com/<username>/<project>.git)' -> #httpsUrl)} ] ]


### PR DESCRIPTION
This PR remove a lot of the usage of Object>>iconNamed: 

It does not remove everything but this is a first pass.