### PR TITLE
1106-Moving-a-class-between-packages-not-properly-catched

### DIFF
--- a/Iceberg.package/IceSystemEventListener.class/class/handleClassChange..st
+++ b/Iceberg.package/IceSystemEventListener.class/class/handleClassChange..st
@@ -2,4 +2,4 @@ event handling
 handleClassChange: aClassChange
 
 	"We should take care not only about the class package but also the package of the methods extending that class."
-	self handlePackagesChange: aClassChange classAffected packages
+	self handlePackagesChange: aClassChange packagesAffected


### PR DESCRIPTION
Fix issue #1106
Correctly ask the announcement for the affected packages and not to the class.