### PR TITLE
Load tonel as pre-load action

### DIFF
--- a/scripts/preLoading.st
+++ b/scripts/preLoading.st
@@ -50,3 +50,9 @@ Metacello new
   baseline: 'Tonel';
   repository: 'github://pharo-vcs/tonel:v1.0.11';
   load.
+
+Metacello new
+    baseline: 'Metacello';
+    repository: 'github://metacello/metacello:pharo-6.1_dev/repository';
+    onConflict: [ :ex | ex allow ];
+    load.

--- a/scripts/preLoading.st
+++ b/scripts/preLoading.st
@@ -43,3 +43,10 @@ do: [ :each |
             ifNotNil: [ :package |
                 ('Removing ', each) logCr.
                 package removeFromSystem ] ].
+
+"Loading Tonel before trying to load Iceberg.
+This is required to load iceberg packages and dependencies in Tonel format"
+Metacello new
+  baseline: 'Tonel';
+  repository: 'github://pharo-vcs/tonel:v1.0.11';
+  load.


### PR DESCRIPTION
Since now commander (and possibly in the future iceberg itself and its dependencies) might be in tonel format, we need to load tonel before attempting to load. 

Follow-up of the original issue in here: https://github.com/pharo-vcs/iceberg/pull/1125