### PR TITLE
Fixing Issue #1158. Libraries should be loaded  using absolute paths.

### DIFF
--- a/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/libGit..st
+++ b/BaselineOfIceberg.package/BaselineOfIceberg.class/instance/libGit..st
@@ -4,7 +4,7 @@ libgit: spec
 		baseline: 'LibGit' 
 		with: [ 
 			spec
-				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v1.5.5';
+				repository: 'github://pharo-vcs/libgit2-pharo-bindings:v1.5.6';
   				loads: 'default' ].
 	spec  
 		project: 'LibGit-Tests'


### PR DESCRIPTION
It requires a new version of LibGit