### PR TITLE
Fix #949

### DIFF
--- a/Iceberg-Metacello-Integration.package/IceGithubRepositoryType.class/instance/mcRepository.st
+++ b/Iceberg-Metacello-Integration.package/IceGithubRepositoryType.class/instance/mcRepository.st
@@ -3,7 +3,10 @@ mcRepository
 	| baseRepo |
 	
 	self guessRegisteredRepository
-		ifNotNil: [ :repo | ^ repo metacelloAdapter: self projectVersion ].
+		ifNotNil: [ :repo | 
+			repo isValid ifTrue: [ ^ repo metacelloAdapter: self projectVersion  ].
+			"If the repo is not valid, we forget it and reget a new one. Because Metacello want to use it"
+			repo forget	].
 		
 	baseRepo := self mcRepositoryClass location: self location.
 	^ (Iceberg icebergRepositoriesURLs includes: baseRepo scpUrl)

--- a/Iceberg-Metacello-Integration.package/IceProviderRepositoryType.class/instance/mcRepository.st
+++ b/Iceberg-Metacello-Integration.package/IceProviderRepositoryType.class/instance/mcRepository.st
@@ -3,7 +3,12 @@ mcRepository
 	| baseRepo |
 	
 	self guessRegisteredRepository
-		ifNotNil: [ :repo | ^ repo metacelloAdapter: self projectVersion  ].
+		ifNotNil: [ :repo | 
+			
+			repo isValid ifTrue: [ ^ repo metacelloAdapter: self projectVersion ].
+			"If the repo is not valid, we forget it and reget a new one. Because Metacello want to use it"
+			repo forget.
+		].
 	
 	baseRepo := self mcRepositoryClass location: self location.
 	^ baseRepo getOrCreateIcebergRepository metacelloAdapter: self projectVersion

--- a/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/repositoryName.st
+++ b/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/repositoryName.st
@@ -1,0 +1,4 @@
+configuring
+repositoryName
+	
+	^ 'test-project-source-properties-tonel'

--- a/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/setUp.st
+++ b/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/setUp.st
@@ -1,0 +1,14 @@
+tests
+setUp
+
+	super setUp.
+	
+	Metacello new
+		baseline: 'PharoGitTest';
+		repository:'github://pharo-vcs/test-project-source-properties-tonel';
+		load.
+		
+	(IceRepository registry select: [ :e | e name = 'test-project-source-properties-tonel' ])
+		do: [ :e | e location ensureDeleteAll ]
+
+	

--- a/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/tearDown.st
+++ b/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/tearDown.st
@@ -1,0 +1,15 @@
+tests
+tearDown
+
+	super tearDown.
+	
+	(IceRepository registry select: [ :e | e name = 'test-project-with-dep' ]) do: [ :each | each ifNotNil: [ :repo |
+		repo unload.
+		repo forget.
+		repo location ifNotNil: #ensureDeleteAll ] ].
+
+	"Cleanup Metacello registry to avoid conflicts"		
+	MetacelloProjectRegistration registry baselineRegistry
+		detect: [ :registration | registration projectName = 'TestProjectWithDep' ]
+		ifFound: [ :registration | registration unregisterProject ].
+	

--- a/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/testMissingRepositoryShouldNotFail.st
+++ b/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/instance/testMissingRepositoryShouldNotFail.st
@@ -1,0 +1,8 @@
+tests
+testMissingRepositoryShouldNotFail
+
+	Metacello new
+		baseline: 'PharoGitTest';
+		repository:'github://pharo-vcs/test-project-source-properties-tonel';
+		load.
+			

--- a/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/properties.json
+++ b/Iceberg-Tests-MetacelloIntegration.package/IceMetacelloIntegrationWithMissingClone.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "AbstractIceMetacelloIntegrationTests",
+	"category" : "Iceberg-Tests-MetacelloIntegration",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "IceMetacelloIntegrationWithMissingClone",
+	"type" : "normal"
+}


### PR DESCRIPTION
Fix #949 
When a repositoriy is missing and used by metacello, everything explodes. 
The repository should be recloned.