### PR TITLE
Add adopt option

### DIFF
--- a/Iceberg-Tests/IceMultiplePackageRepositoryTest.class.st
+++ b/Iceberg-Tests/IceMultiplePackageRepositoryTest.class.st
@@ -10,6 +10,75 @@ IceMultiplePackageRepositoryTest class >> isAbstract [
 	^ self == IceMultiplePackageRepositoryTest
 ]
 
+{ #category : #'tests-commit' }
+IceMultiplePackageRepositoryTest >> testAdoptCommitChangesWorkingCopyCommit [
+
+	| message commitToAdopt |
+	message := 'Added IceGeneratedClassForTesting'.
+	"This is a Ring working copy"
+	self repository workingCopy
+		createClass: 'IceGeneratedClassForTesting' 
+		inPackage: self packageName1 asSymbol.
+	self repository commitWithMessage: message.
+
+	commitToAdopt := self repository branch commit parent.
+	commitToAdopt adopt.
+	
+	self assert: self repository workingCopy referenceCommit equals: commitToAdopt
+]
+
+{ #category : #'tests-commit' }
+IceMultiplePackageRepositoryTest >> testAdoptCommitDoesNotChangeBranchCommit [
+
+	| message commitToAdopt branchCommitBeforeAdopt |
+	message := 'Added IceGeneratedClassForTesting'.
+	"This is a Ring working copy"
+	self repository workingCopy
+		createClass: 'IceGeneratedClassForTesting' 
+		inPackage: self packageName1 asSymbol.
+	self repository commitWithMessage: message.
+
+	branchCommitBeforeAdopt := self repository branch commit.
+	commitToAdopt := branchCommitBeforeAdopt parent.
+	commitToAdopt adopt.
+	
+	self assert: self repository branch commit equals: branchCommitBeforeAdopt 
+]
+
+{ #category : #'tests-commit' }
+IceMultiplePackageRepositoryTest >> testAdoptCommitDoesNotChangeCheckedOutCodeInImage [
+
+	| message commitToAdopt |
+	message := 'Added IceGeneratedClassForTesting'.
+	"This is a Ring working copy"
+	self repository workingCopy
+		createClass: 'IceGeneratedClassForTesting' 
+		inPackage: self packageName1 asSymbol.
+	self repository commitWithMessage: message.
+
+	commitToAdopt := self repository branch commit parent.
+	commitToAdopt adopt.
+	
+	self assert: (self repository workingCopy environment ask includesClassNamed: 'IceGeneratedClassForTesting')
+]
+
+{ #category : #'tests-commit' }
+IceMultiplePackageRepositoryTest >> testAdoptCommitMarksPackagesAsDirty [
+
+	| message commitToAdopt |
+	message := 'Added IceGeneratedClassForTesting'.
+	"This is a Ring working copy"
+	self repository workingCopy
+		createClass: 'IceGeneratedClassForTesting' 
+		inPackage: self packageName1 asSymbol.
+	self repository commitWithMessage: message.
+
+	commitToAdopt := self repository branch commit parent.
+	commitToAdopt adopt.
+	
+	self assert: (self repository workingCopy packageNamed: self packageName1 asSymbol) isDirty
+]
+
 { #category : #'tests-checkout' }
 IceMultiplePackageRepositoryTest >> testCheckoutBranchDoesNotLeaveDetachedHead [
 

--- a/Iceberg-TipUI/IceTipAdoptCommitCommand.class.st
+++ b/Iceberg-TipUI/IceTipAdoptCommitCommand.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #IceTipAdoptCommitCommand,
+	#superclass : #IceTipCommand,
+	#instVars : [
+		'selectedCommitish',
+		'selectedBranch'
+	],
+	#category : #'Iceberg-TipUI-Commands'
+}
+
+{ #category : #activation }
+IceTipAdoptCommitCommand class >> browserHistoryContextActivation [
+	<classAnnotation>
+	
+	^ CmdContextMenuActivation
+		byRootGroupItemOrder: 10
+		for: IceTipHistoryContext
+]
+
+{ #category : #accessing }
+IceTipAdoptCommitCommand class >> defaultHelp [
+	^ 'Sets this commit as the commit of your working copy. It will not modify your loaded code, but it will calculate the differences between your loaded packages and the the new commit to mark packages as dirty.'
+]
+
+{ #category : #activation }
+IceTipAdoptCommitCommand class >> defaultMenuIconName [
+	^ #recoverLostChanges
+]
+
+{ #category : #execution }
+IceTipAdoptCommitCommand >> defaultMenuItemName [
+
+	^ 'Adopt commit ', selectedCommitish shortId
+]
+
+{ #category : #execution }
+IceTipAdoptCommitCommand >> execute [
+	
+	selectedCommitish adopt.
+	Iceberg announcer announce: (IceRepositoryModified for: self repositoryModel entity)
+]
+
+{ #category : #execution }
+IceTipAdoptCommitCommand >> readParametersFromContext: aToolContext [
+	super readParametersFromContext: aToolContext.
+	selectedCommitish := aToolContext item
+]

--- a/Iceberg-TipUI/IceTipCommitModel.class.st
+++ b/Iceberg-TipUI/IceTipCommitModel.class.st
@@ -9,6 +9,12 @@ Class {
 	#category : 'Iceberg-TipUI-Model'
 }
 
+{ #category : #'API-commits' }
+IceTipCommitModel >> adopt [
+	
+	self entity adopt
+]
+
 { #category : #accessing }
 IceTipCommitModel >> ancestorShortId [
 	^ self entity ancestors first shortId


### PR DESCRIPTION
Add the adopt option in the UI.This option will set the selected commit as the current working copy commit, without checking out the commit.