### PR TITLE
1217-Introduce-Hiedra-to-repository-browser

### DIFF
--- a/Iceberg-TipUI/IceTipHiedraDataSource.class.st
+++ b/Iceberg-TipUI/IceTipHiedraDataSource.class.st
@@ -1,0 +1,74 @@
+"
+I am a datasource for the IceTipHiedraHistoryBrowser.
+"
+Class {
+	#name : #IceTipHiedraDataSource,
+	#superclass : #IceTipDataSource,
+	#instVars : [
+		'hiedraColumnController'
+	],
+	#category : #'Iceberg-TipUI-View-DataSource'
+}
+
+{ #category : #accessing }
+IceTipHiedraDataSource >> cellColumn: column row: rowIndex [
+	"Answer a morph with the cell view. I will probably return a FTCellMorph."
+	
+	column id = ' ' ifTrue: [ 
+		^ FTCellMorph new
+			addMorphBack: (hiedraColumnController cellMorphAtRow: rowIndex);
+			yourself
+		].
+	
+	^ super cellColumn: column row: rowIndex
+]
+
+{ #category : #accessing }
+IceTipHiedraDataSource >> elements: commits [
+
+	super elements: commits.
+
+	self table ifNil: [ ^self ].
+		
+	"Adjust the ruler rendering settings with table's row height."
+	hiedraColumnController renderer rowHeight: self table rowHeight floor.
+
+	"Create a new ruler model with the new elements"
+	self refreshRulerWithCurrentElements.
+
+	"Reset the visualization"
+	hiedraColumnController reset.
+	
+	"Adjust the column width in the table"
+	self table columns first width: hiedraColumnController rulerWidth.
+
+]
+
+{ #category : #accessing }
+IceTipHiedraDataSource >> initialize [
+	
+	super initialize.
+
+	hiedraColumnController := HiColumnController new.
+	hiedraColumnController renderer
+		arrowSize: 0;
+		nodeConnectionOffset: 0;
+		nodeRadius: 1.75.
+]
+
+{ #category : #accessing }
+IceTipHiedraDataSource >> refreshRulerWithCurrentElements [
+
+	| ancestorIds |
+	ancestorIds := Dictionary new.
+	elements do: [ :aCommit |
+		"Note: Hiedra expects each ancestor id corresponds to a commit in elements."
+		ancestorIds
+			at: aCommit id
+			put: aCommit entity ancestorIds ].
+
+	hiedraColumnController ruler: (HiRulerBuilder
+		newRulerValues: (elements collect: #id) "Note: ids should keep the original order."
+		linksBlock: [ :id | ancestorIds at: id ]).
+
+]

--- a/Iceberg-TipUI/IceTipHiedraHistoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipHiedraHistoryBrowser.class.st
@@ -1,0 +1,28 @@
+"
+I add a Hiedra column to the browser defined by my superclass. This column visualizes the relationship between commits in the history list.
+"
+Class {
+	#name : #IceTipHiedraHistoryBrowser,
+	#superclass : #IceTipHistoryBrowser,
+	#category : #'Iceberg-TipUI-View'
+}
+
+{ #category : #initialization }
+IceTipHiedraHistoryBrowser >> initializeCommitList [
+
+	"Add the Hiedra column at the beginning. The Datasource has the logic to render it."
+	commitList widget addColumn:
+		(IceTipTableColumn new
+			id: ' ';
+			yourself).
+
+	super initializeCommitList.
+]
+
+{ #category : #'private factory' }
+IceTipHiedraHistoryBrowser >> newCommitsDataSource [
+	^ IceTipHiedraDataSource new 
+		tool: self;
+		elements: #(); "It will be set when refreshing"
+		yourself
+]

--- a/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoryBrowser.class.st
@@ -80,7 +80,7 @@ IceTipRepositoryBrowser >> initializeWidgets [
 	super initializeWidgets.	
 	
 	sidebarTree := self newIceOutline.
-	historyPanel := self instantiate: IceTipHistoryBrowser on: self model headModel.
+	historyPanel := self instantiate: IceTipHiedraHistoryBrowser on: self model headModel.
 	historyPanel beForMerge.
 	
 	self initializeSidebarTree.


### PR DESCRIPTION
Add a Hiedra column to the Repository window. 

I adds a delay when the window is opened because it is not asynchronous. But I think the information it adds makes it worth. 
In small branches it was a few milliseconds in my laptop, and the worst case I tested is 500ms slowdown with the dev-1.0 branch of the iceberg repository (>2800 commits).
The rendering part is not significant in performance because it uses a kind of pagination. For example, if a fasttable is opened and only the top 20 rows are visible, only one "page" of 30 rows are rendered and cached initially. When user scrolls the table, more pages of 30 rows are rendered on demand.
What could be optimized yet is the graph model: when the fasttable is opened, Hiedra currently iterates over all the commits and parents to create the model. But I don't plan to work in this optimization for the moment... so please test it.

IMPORTANT: It works in latest Pharo 8 + PR #2926 (https://github.com/pharo-project/pharo/pull/2926).