### PR TITLE
Adapt UI so the text is not cut on the right

### DIFF
--- a/Iceberg-TipUI.package/IceTipRemoveRepositoryDialog.class/class/defaultSpec.st
+++ b/Iceberg-TipUI.package/IceTipRemoveRepositoryDialog.class/class/defaultSpec.st
@@ -5,7 +5,7 @@ defaultSpec
 	^ SpecLayout composed 
 		newRow: [ :row |
 			row 
-				newColumn: #iconPanel width: 40 * World displayScaleFactor;
+				newColumn: #iconPanel width: World displayScaleFactor;
 				newColumn: [ :column |
 					column 
 						newRow: #confirmLabel;


### PR DESCRIPTION
The text was crop on the right.

![Screenshot 2019-05-30 at 15 27 06](https://user-images.githubusercontent.com/327334/58639694-7009dd00-82ef-11e9-91e1-1402c438ddf4.png)
