### PR TITLE
Feature: add generic git repository

### DIFF
--- a/Iceberg-Metacello-Integration/IceGitRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceGitRepositoryType.class.st
@@ -1,0 +1,25 @@
+"
+I resolve a generic git repository.
+
+I accept direct URLs as my parameter to form a repository using a MCGitRemoteRepository. I can parse then this kind of urls:
+
+git:https://github.com/user/project.git
+git:git@github.com:user/project.git
+"
+Class {
+	#name : #IceGitRepositoryType,
+	#superclass : #IceProviderRepositoryType,
+	#category : #'Iceberg-Metacello-Integration'
+}
+
+{ #category : #accessing }
+IceGitRepositoryType class >> type [
+
+	^ 'git'
+]
+
+{ #category : #accessing }
+IceGitRepositoryType >> mcRepositoryClass [
+	
+	^ MCGitRemoteRepository
+]

--- a/Iceberg-Metacello-Integration/IceMetacelloRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceMetacelloRepositoryType.class.st
@@ -8,16 +8,18 @@ Class {
 	#instVars : [
 		'location'
 	],
-	#category : 'Iceberg-Metacello-Integration'
+	#category : #'Iceberg-Metacello-Integration'
 }
 
 { #category : #accessing }
 IceMetacelloRepositoryType class >> allTypes [
-	^ self allSubclasses select: [ :each | each isAbstract not ]
+
+	^ self allSubclasses reject: [ :each | each isAbstract ]
 ]
 
 { #category : #testing }
 IceMetacelloRepositoryType class >> canHandleType: aType [ 
+
 	^ self allTypes
 		anySatisfy: [ :each | each isSuitableForType: aType ]  
 	
@@ -25,6 +27,7 @@ IceMetacelloRepositoryType class >> canHandleType: aType [
 
 { #category : #private }
 IceMetacelloRepositoryType class >> extractTypeOf: aString [ 
+
 	^ aString copyUpTo: $:
 ]
 

--- a/Iceberg-Metacello-Integration/IceProviderRepositoryType.class.st
+++ b/Iceberg-Metacello-Integration/IceProviderRepositoryType.class.st
@@ -22,7 +22,7 @@ Metacello new
 Class {
 	#name : #IceProviderRepositoryType,
 	#superclass : #IceMetacelloRepositoryType,
-	#category : 'Iceberg-Metacello-Integration'
+	#category : #'Iceberg-Metacello-Integration'
 }
 
 { #category : #testing }
@@ -47,12 +47,10 @@ IceProviderRepositoryType >> mcRepository [
 	
 	self guessRegisteredRepository
 		ifNotNil: [ :repo | 
-			
 			repo isValid ifTrue: [ ^ repo metacelloAdapter: self projectVersion ].
-			"If the repo is not valid, we forget it and reget a new one. Because Metacello want to use it"
-			repo forget.
-		].
-	
+			"If the repo is not valid, we forget it and reget a new one. 
+			 Because Metacello want to use it"
+			repo forget ].
 	baseRepo := self mcRepositoryClass location: self location.
 	^ baseRepo getOrCreateIcebergRepository metacelloAdapter: self projectVersion
 ]

--- a/Iceberg-Metacello-Integration/MCGitRemoteRepository.class.st
+++ b/Iceberg-Metacello-Integration/MCGitRemoteRepository.class.st
@@ -1,0 +1,135 @@
+"
+I am a repository managing projects hosted on generic git repositories.
+
+I accept urls of the kind: 
+
+https://github.com/user/project.git
+git@github.com:user/project.git
+
+WARNING: This repository is meant to be used with iceberg and it will not work with plain Monticello/Metacello (because there is no way to know how to download a zip)
+"
+Class {
+	#name : #MCGitRemoteRepository,
+	#superclass : #MCGitBasedNetworkRepository,
+	#instVars : [
+		'location',
+		'host',
+		'port',
+		'path',
+		'user'
+	],
+	#category : #'Iceberg-Metacello-Integration'
+}
+
+{ #category : #accessing }
+MCGitRemoteRepository class >> basicDescription [
+
+  ^ 'git'
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository class >> description [
+
+  ^ self basicDescription , ':'
+]
+
+{ #category : #private }
+MCGitRemoteRepository class >> parseLocation: aLocation version: aVersion [ 
+
+	^ self new
+	parseLocation: (aLocation allButFirst: self description size);
+	yourself 
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> host [
+
+	^ host
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> httpsUrl [
+
+	^ 'https://{1}{2}/{3}.git' format: { 
+		self host. 
+		self port 
+			ifNotNil: [ ':', self port asString ]
+			ifNil: [ '' ].
+		self path }
+]
+
+{ #category : #initialization }
+MCGitRemoteRepository >> initialize [
+	
+	super initialize.
+]
+
+{ #category : #initialize }
+MCGitRemoteRepository >> parseHTTPLocation: aString [
+	| url |
+
+	url := aString asUrl.
+	host := url host.
+	port := url port.
+	path := self pathFrom: url path
+]
+
+{ #category : #initialize }
+MCGitRemoteRepository >> parseLocation: aString [
+
+	(#('http:' 'https:') 
+		anySatisfy: [ :each | aString beginsWith: each ])
+		ifTrue: [ self parseHTTPLocation: aString ]
+		ifFalse: [ self parseSSHLocation: aString ]
+]
+
+{ #category : #initialize }
+MCGitRemoteRepository >> parseSSHLocation: aString [
+	| segments |
+	
+	segments := aString substrings: '@:'.
+	user := segments first.
+	host := segments second.
+	path := self pathFrom: segments third
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> path [
+
+	^ path
+]
+
+{ #category : #initialize }
+MCGitRemoteRepository >> pathFrom: aString [
+
+	^ (aString endsWith: '.git')
+		ifTrue: [ aString allButLast: 4 ]
+		ifFalse: [ aString ]
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> port [
+
+	^ port
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> projectPath [
+
+	^ self path
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> scpUrl [
+
+	^ '{1}@{2}/{3}.git' format: { 
+		self user. 
+		self host. 
+		self path }
+]
+
+{ #category : #accessing }
+MCGitRemoteRepository >> user [
+
+	^ user
+]

--- a/Iceberg/IceAnnouncer.class.st
+++ b/Iceberg/IceAnnouncer.class.st
@@ -7,33 +7,47 @@ In current implementation of Iceberg, I will be used mainly for the convenience 
 "
 Class {
 	#name : #IceAnnouncer,
-	#superclass : #GLMAnnouncer,
+	#superclass : #Announcer,
 	#instVars : [
-		'suspendedConditions'
+		'suspendedConditions',
+		'suspendAll'
 	],
-	#category : 'Iceberg-Core'
+	#category : #'Iceberg-Core'
 }
+
+{ #category : #announce }
+IceAnnouncer >> announce: anAnnouncement [
+
+	(self isAnnouncementSuspended: anAnnouncement) ifTrue: [ ^ anAnnouncement asAnnouncement ].
+	^ super announce: anAnnouncement
+]
 
 { #category : #initialization }
 IceAnnouncer >> initialize [
+
 	super initialize.
+	suspendAll := false.
 	suspendedConditions := OrderedCollection new: 5
 ]
 
 { #category : #testing }
 IceAnnouncer >> isAnnouncementSuspended: anAnnouncement [
-	^ (super isAnnouncementSuspended: anAnnouncement) 
-		or: [ self isMatchingAnnouncementSuspended: anAnnouncement ]
+
+	suspendAll ifTrue: [ ^ true ].
+	suspendedConditions ifEmpty: [ ^ false ].
+	^ suspendedConditions anySatisfy: [ :each | 
+		each value: anAnnouncement ]
 ]
 
 { #category : #testing }
-IceAnnouncer >> isMatchingAnnouncementSuspended: anAnnouncement [
-	suspendedConditions ifEmpty: [ ^ false ].
-	^ suspendedConditions anySatisfy: [ :each | each value: anAnnouncement ]
+IceAnnouncer >> isSuspended [
+
+	^ suspendAll
 ]
 
 { #category : #suspending }
 IceAnnouncer >> suspendAllForRepository: aRepository while: aBlock [
+
 	^ self 
 		suspendAllMatching: [ :ann | ann appliesToRepository: aRepository ] 
 		while: aBlock 
@@ -41,6 +55,17 @@ IceAnnouncer >> suspendAllForRepository: aRepository while: aBlock [
 
 { #category : #suspending }
 IceAnnouncer >> suspendAllMatching: matchBlock while: aBlock [
+
 	suspendedConditions add: matchBlock.
 	aBlock ensure: [ suspendedConditions remove: matchBlock ]
+]
+
+{ #category : #suspending }
+IceAnnouncer >> suspendAllWhile: aBlock [
+	| previousSuspensionState |
+	
+	previousSuspensionState := suspendAll.
+	suspendAll := true.
+	aBlock ensure: [ 
+		suspendAll := previousSuspensionState ]
 ]

--- a/Iceberg/IceMCVersionInfo.class.st
+++ b/Iceberg/IceMCVersionInfo.class.st
@@ -18,7 +18,7 @@ IceMCVersionInfo class >> package: package message: commitMessage [
 ]
 
 { #category : #utilities }
-IceMCVersionInfo class >> uuidFromCommit: aCommit package: aPackage. [
+IceMCVersionInfo class >> uuidFromCommit: aCommit package: aPackage [.
 	^ self uuidFromSHA: (SHA1 new hashStream: (ReadStream on: aCommit id, aPackage name))
 
 ]


### PR DESCRIPTION
this will allow users to declare repositories like this: 

```Smalltalk
Metacello new 
	repository: 'git:https://someprivaterepo.com/path/to/project.git';
	baseline: 'MyBaseline';
	load.
```

or

```Smalltalk
Metacello new 
	repository: 'git:git@someprivaterepo.com:path/to/project.git';
	baseline: 'MyBaseline';
	load.
```