### PR TITLE
1345-The-IcePushed-and-IceCommited-announcement-are-never-announced

### DIFF
--- a/Iceberg-TipUI/IceTipCommitAction.class.st
+++ b/Iceberg-TipUI/IceTipCommitAction.class.st
@@ -9,7 +9,7 @@ Class {
 		'items',
 		'message'
 	],
-	#category : 'Iceberg-TipUI-Commands'
+	#category : #'Iceberg-TipUI-Commands'
 }
 
 { #category : #executing }
@@ -22,7 +22,7 @@ IceTipCommitAction >> basicExecute [
 				commitChanges: (diff copyWithOnly: items)
 				withMessage: message ].
 	Iceberg announcer announce: (IceRepositoryModified for: self repository).
-	
+	Iceberg announcer announce: (IceCommited for: self repository).
 ]
 
 { #category : #accessing }

--- a/Iceberg-TipUI/IceTipPushAction.class.st
+++ b/Iceberg-TipUI/IceTipPushAction.class.st
@@ -13,5 +13,5 @@ IceTipPushAction >> basicExecute [
 		informUser: 'Pushing...' 
 		during: [ self repository push ].
 	Iceberg announcer announce: (IceRepositoryModified for: self repository).
-	
+	Iceberg announcer announce: (IcePushed for: self repository).
 ]


### PR DESCRIPTION
Adding the announcing of push and commit on the commands commit/ push. It is really simple add of announcement. It does not add tests, since i don't have an implication, is just for articulating other applications. Maybe we should discuss on how and why to test the announcements.