### PR TITLE
1356-DNU-when-pasting-url-of-github-project-to-Clone-remote-Repository-Regression

### DIFF
--- a/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipGitRepositoryPanel.class.st
@@ -53,7 +53,7 @@ IceTipGitRepositoryPanel >> initializeWidgets [
 	self remoteInputText ghostText: 'e.g., ssh://[user@]host.xz[:port]/path/to/repo.git'.
 	
 	self remoteInputText 	whenTextChanged: [ :text |
-		self projectLocation appendPath: (self extractProjectName: text) ].
+		self projectLocation appendPath: (self extractProjectName: text asString) ].
 	
 	self focusOrder 
 		add: self remoteInputText	

--- a/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
+++ b/Iceberg-TipUI/IceTipNewRepositoryPanel.class.st
@@ -74,7 +74,7 @@ IceTipNewRepositoryPanel >> initializeWidgets [
 		autoAccept: true.
 	
 	projectNameInputText 	whenTextChanged: [ :text | 
-		projectLocation appendPath: text ].
+		projectLocation appendPath: text asString ].
 	
 	self focusOrder 
 		add: self projectNameInputText;


### PR DESCRIPTION
The text changed announcement can come with a Text, so we need to convert it to String if needed.

This is a problem of the under deprecation Spec1, I fix it here because modifying Spec1 to handle both cases is more work and it is something we are going to throw away.