### PR TITLE
made the caches threadsafe

### DIFF
--- a/Iceberg-Libgit/IceLibgitRepository.class.st
+++ b/Iceberg-Libgit/IceLibgitRepository.class.st
@@ -303,7 +303,7 @@ IceLibgitRepository >> codeDirectory [
 { #category : #'private-commits' }
 IceLibgitRepository >> commitCache [
 	
-	^ commitCache ifNil: [ commitCache := LRUCache new maximumWeight: 30  ]
+	^ commitCache ifNil: [ commitCache := LRUCache new maximumWeight: 30; beThreadSafe  ]
 ]
 
 { #category : #'private-commits' }

--- a/Iceberg/IceRepository.class.st
+++ b/Iceberg/IceRepository.class.st
@@ -151,7 +151,7 @@ Class {
 	#classVars : [
 		'Registry'
 	],
-	#category : 'Iceberg-Core'
+	#category : #'Iceberg-Core'
 }
 
 { #category : #testing }
@@ -381,7 +381,7 @@ IceRepository >> commitishNamed: aName [
 { #category : #'private-commits' }
 IceRepository >> commitsInPackageCache [
 
-	^ commitsInPackageCache ifNil: [ commitsInPackageCache := LRUCache new maximumWeight: 30  ]
+	^ commitsInPackageCache ifNil: [ commitsInPackageCache := LRUCache new maximumWeight: 30; beThreadSafe  ]
 ]
 
 { #category : #'private-commits' }


### PR DESCRIPTION
The views in gt are rendered in a bg thread and because of that they can access the same repository instance at the same time. This can lead to errors like the one in the attached screenshot. 
<img width="2032" alt="Screenshot 2020-04-01 at 16 53 57" src="https://user-images.githubusercontent.com/3874710/78545039-c85d1580-7803-11ea-8d23-ba69b75a244c.png">
