### PR TITLE
Fix: Tabs could not show after adding a project

### DIFF
--- a/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
+++ b/Iceberg-TipUI/IceTipRepositoriesBrowser.class.st
@@ -232,6 +232,9 @@ IceTipRepositoriesBrowser >> projectsPanelRepositoryModels [
 { #category : 'private' }
 IceTipRepositoriesBrowser >> refresh [
 
+	"In case we added a project that is an a different group than a group we already have, we update the full presenter to refresh the whole notebook."
+	(self model repositoryGroups anySatisfy: [ :group | (repositoryNotebook hasPageNamed: group label) not ]) ifTrue: [ ^ self updatePresenter ].
+
 	repositoryNotebook selectedPage ifNil: [ ^ self ].
 	repositoryNotebook selectedPage activePresenter updatePresenter
 ]


### PR DESCRIPTION
If we have a project in a special Iceberg tab and we add it to Iceberg while no other project is in this tab, then we need to close and reopen iceberg to see its tab and select our project. 

Here is a fix. If we have a new tab, we refresh the whole notebook instead of refreshing the active tab